### PR TITLE
Rename problem to "Singly-Linked List"

### DIFF
--- a/linked-list.yml
+++ b/linked-list.yml
@@ -1,4 +1,4 @@
 ---
-blurb: "Write a simple linked list implementation that uses the Proxy pattern"
+blurb: "Write a Singly-Linked List implementation that uses the Proxy pattern"
 source: "Inspired by 'Data Structures and Algorithms with Object-Oriented Design Patterns in Ruby', singly linked-lists."
 source_url: "http://www.brpreiss.com/books/opus8/html/page96.html#SECTION004300000000000000000"


### PR DESCRIPTION
According to the source_url the problem is called Singly-Linked List
https://github.com/exercism/x-common/blob/master/linked-list.md

We already have a https://github.com/exercism/x-common/blob/master/simple-linked-list.yml

Using this description would be more accurate for the problem name itself used in the JSON files in each track.