### PR TITLE
Reword the blurb of accumulate to make the arguments clear

### DIFF
--- a/accumulate.yml
+++ b/accumulate.yml
@@ -1,4 +1,4 @@
 ---
-blurb: "Implement the `accumulate` operation, which, given a collection and an operation to perform on each element of the collection, returns a new collection containing the result of applying that operation to each element of the input collection."
+blurb: "Implement the `accumulate` operation, which, given an operation and a collection applies that operation to each element of the collection and returns a new collection containing the result of applying that operation to each element of the input collection."
 source: "Conversation with James Edward Gray II"
 source_url: "https://twitter.com/jeg2"


### PR DESCRIPTION
Currently the blurb suggests that the `accumulate` function should have the following signature:
```haskell
accumulate [a] -> (a -> b) -> [b]
```
However the test suite assumes that `accumulate` has the following signature:
```haskell
accumulate (a -> b) -> [a] -> [b]
```
