### PR TITLE
Add comma in "Hello, world!" instruction blurb.

### DIFF
--- a/hello-world.yml
+++ b/hello-world.yml
@@ -1,4 +1,4 @@
 ---
-blurb: 'Write a program that greets the user by name, or by saying "Hello world!" if no name is given.'
+blurb: 'Write a program that greets the user by name, or by saying "Hello, world!" if no name is given.'
 source: "This is a program to introduce users to using Exercism"
 source_url: "http://en.wikipedia.org/wiki/%22Hello,_world!%22_program"


### PR DESCRIPTION
The comma is necessary for the test to authenticate in Python (and also in the other examples I checked, though I did not check all of them).