### PR TITLE
Point out that using MAPCAR is idiomatic Lisp

### DIFF
--- a/accumulate.md
+++ b/accumulate.md
@@ -20,3 +20,6 @@ Solve this one yourself using other basic tools instead.
 
 Elixir specific: it's perfectly fine to use `Enum.reduce` or
 `Enumerable.reduce`.
+
+Lisp specific: it's perfectly fine to use `MAPCAR` or the equivalent,
+as this is idiomatic Lisp, not a library function.


### PR DESCRIPTION
Like the caveat about Erlang, it should be pointed out that using `MAPCAR` is the standard Lisp-y way of doing things - the alternative is the Common Lisp `LOOP` macro, which actually isn't very idiomatic of Lisp in general.