### PR TITLE
Slim down robot-simulator README

### DIFF
--- a/robot-simulator.md
+++ b/robot-simulator.md
@@ -1,7 +1,6 @@
-## Step 1
+A robot factory's test facility needs a program to verify robot movements.
 
-The robot factory manufactures robots that have three possible
-movements:
+The robots have three possible movements:
 
 - turn right
 - turn left
@@ -9,49 +8,11 @@ movements:
 
 Robots are placed on a hypothetical infinite grid, facing a particular
 direction (north, east, south, or west) at a set of {x,y} coordinates,
-e.g., {3,8}.
-
-## Step 2
-
-Robots can pivot left and right.
-
-The robot factory manufactures robots that have three possible
-movements:
-
-- turn right
-- turn left
-- advance
-
-The factory's test facility needs a program to verify robot movements.
-
-There are a number of different rooms of varying sizes, measured in
-Robot Units, the distance a robot moves when you instruct it to
-`advance`.
-
-The floor of the room is a grid, each square of which measures 1 square
-RU (Robot Unit).
-
-The rooms are always oriented so that each wall faces east, south, west,
-and north.
-
-The test algorithm is to place a robot at a coordinate in the room,
-facing in a particular direction.
+e.g., {3,8}, with coordinates increasing to the north and east.
 
 The robot then receives a number of instructions, at which point the
 testing facility verifies the robot's new position, and in which
 direction it is pointing.
-
-## Step 3
-
-The robot factory manufactures robots that have three possible
-movements:
-
-- turn right
-- turn left
-- advance
-
-The robot factory's test facility has a simulator which can take a
-string of letters and feed this into a robot as instructions.
 
 - The letter-string "RAALAL" means:
   - Turn right


### PR DESCRIPTION
* Eliminate redundancy in instructions.
* Eliminate confusing language about constrained rooms of different sizes,
  appears to have been legacy text irrelevant to this problem.
* Eliminate step headers (also legacy?).
* Clarify that coordinates increase when moving north and east.