### PR TITLE
Make README match tests as best as I can determine

### DIFF
--- a/bank-account.md
+++ b/bank-account.md
@@ -5,9 +5,8 @@ can charge against the account.
 Create an account that can be accessed from multiple threads/processes
 (terminology depends on your programming language).
 
-The account only needs to be available when the bank is open, though it
-may be available at all times. You will get notified when the bank opens
-and closes.
+It should be possible to close an account; operations against a closed
+account must fail.
 
 ## Instructions
 


### PR DESCRIPTION
The bank account challenge is fairly uncommon, perhaps due to the fact that most languages don't have trivial support for concurrency.

Of the 3 examples I've found thus far (go, erlang, clojure) 2 of them reinterpreted (or misinterpreted) the bank closure paragraph as account closure; clojure ignored it entirely.

So, let's make the theory reflect practice instead of the other way around.