### PR TITLE
Fixes "Cysteine" typo

### DIFF
--- a/protein-translation.md
+++ b/protein-translation.md
@@ -37,7 +37,7 @@ UCU, UCC, UCA, UCG    |Serine
 
 UAU, UAC              |Tyrosine
 
-UGU, UGC              |Cystine
+UGU, UGC              |Cysteine
 
 UGG                   |Tryptophan
 


### PR DESCRIPTION
Because cystine is something else entirely.

Minor, but I am a protein scientist and care about such things.