### PR TITLE
word-count: tweak normalization test case

### DIFF
--- a/word-count.json
+++ b/word-count.json
@@ -27,8 +27,8 @@
         },
         {
             "description": "normalize case",
-            "input": "go Go GO",
-            "expected": { "go" : 3 }
+            "input": "go Go GO Stop stop",
+            "expected": { "go" : 3, "stop" : 2 }
         }
     ]
 }


### PR DESCRIPTION
In exercism/xpython#234 we discussed how adding a second
word in the normalization case might allow
some languages to use sorted counts as a normalization-agnostic
assertion.

I don't know that this will work in practice as allowing people to normalize to a different case, since all the other tests have lowercase words.