### PR TITLE
Food Chain: Test JSON created

### DIFF
--- a/food-chain.json
+++ b/food-chain.json
@@ -1,0 +1,177 @@
+{
+    "#": [
+        "Some languages test for the verse() method, which takes a start verse ",
+        "and optional end verse.",
+        "But other languages have only tested for the full poem.",
+        "For those languages in the latter category, you may wish to only ",
+        "implement the full song test and leave the rest alone, ignoring the start ",
+        "and end verse fields."
+    ],
+    "verse": {
+        "description": "Return specified verse or series of verses",
+        "cases": [
+            {
+                "description": "fly",
+                "start verse": 1,
+                "expected": [
+                    "I know an old lady who swallowed a fly.",
+                    "I don't know why she swallowed the fly. Perhaps she'll die."
+                ]
+            },
+            {
+                "description": "spider",
+                "start verse": 2,
+                "expected": [
+                    "I know an old lady who swallowed a spider.",
+                    "It wriggled and jiggled and tickled inside her.",
+                    "She swallowed the spider to catch the fly.",
+                    "I don't know why she swallowed the fly. Perhaps she'll die."
+                ]
+            },
+            {
+                "description": "bird",
+                "start verse": 3,
+                "expected": [
+                    "I know an old lady who swallowed a bird.",
+                    "How absurd to swallow a bird!",
+                    "She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.",
+                    "She swallowed the spider to catch the fly.",
+                    "I don't know why she swallowed the fly. Perhaps she'll die."
+                ]
+            },
+            {
+                "description": "cat",
+                "start verse": 4,
+                "expected": [
+                    "I know an old lady who swallowed a cat.",
+                    "Imagine that, to swallow a cat!",
+                    "She swallowed the cat to catch the bird.",
+                    "She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.",
+                    "She swallowed the spider to catch the fly.",
+                    "I don't know why she swallowed the fly. Perhaps she'll die."
+                ]
+            },
+            {
+                "description": "dog",
+                "start verse": 5,
+                "expected": [
+                    "I know an old lady who swallowed a dog.",
+                    "What a hog, to swallow a dog!",
+                    "She swallowed the dog to catch the cat.",
+                    "She swallowed the cat to catch the bird.",
+                    "She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.",
+                    "She swallowed the spider to catch the fly.",
+                    "I don't know why she swallowed the fly. Perhaps she'll die."
+                ]
+            },
+            {
+                "description": "goat",
+                "start verse": 6,
+                "expected": [
+                    "I know an old lady who swallowed a goat.",
+                    "Just opened her throat and swallowed a goat!",
+                    "She swallowed the goat to catch the dog.",
+                    "She swallowed the dog to catch the cat.",
+                    "She swallowed the cat to catch the bird.",
+                    "She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.",
+                    "She swallowed the spider to catch the fly.",
+                    "I don't know why she swallowed the fly. Perhaps she'll die."
+                ]
+            },
+            {
+                "description": "cow",
+                "start verse": 7,
+                "expected": [
+                    "I know an old lady who swallowed a cow.",
+                    "I don't know how she swallowed a cow!",
+                    "She swallowed the cow to catch the goat.",
+                    "She swallowed the goat to catch the dog.",
+                    "She swallowed the dog to catch the cat.",
+                    "She swallowed the cat to catch the bird.",
+                    "She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.",
+                    "She swallowed the spider to catch the fly.",
+                    "I don't know why she swallowed the fly. Perhaps she'll die."
+                ]
+            },
+            {
+                "description": "horse",
+                "start verse": 8,
+                "expected": [
+                    "I know an old lady who swallowed a horse.",
+                    "She's dead, of course!"
+                ]
+            },
+            {
+                "description": "multiple verses",
+                "start verse": 1,
+                "end verse": 2,
+                "expected": [
+                    "I know an old lady who swallowed a fly.",
+                    "I don't know why she swallowed the fly. Perhaps she'll die.",
+                    "",
+                    "I know an old lady who swallowed a spider.",
+                    "It wriggled and jiggled and tickled inside her.",
+                    "She swallowed the spider to catch the fly.",
+                    "I don't know why she swallowed the fly. Perhaps she'll die."
+                ]
+            },
+            {
+                "description": "full song",
+                "start verse": 1,
+                "end verse": 8,
+                "expected": [
+                    "I know an old lady who swallowed a fly.",
+                    "I don't know why she swallowed the fly. Perhaps she'll die.",
+                    "",
+                    "I know an old lady who swallowed a spider.",
+                    "It wriggled and jiggled and tickled inside her.",
+                    "She swallowed the spider to catch the fly.",
+                    "I don't know why she swallowed the fly. Perhaps she'll die.",
+                    "",
+                    "I know an old lady who swallowed a bird.",
+                    "How absurd to swallow a bird!",
+                    "She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.",
+                    "She swallowed the spider to catch the fly.",
+                    "I don't know why she swallowed the fly. Perhaps she'll die.",
+                    "",
+                    "I know an old lady who swallowed a cat.",
+                    "Imagine that, to swallow a cat!",
+                    "She swallowed the cat to catch the bird.",
+                    "She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.",
+                    "She swallowed the spider to catch the fly.",
+                    "I don't know why she swallowed the fly. Perhaps she'll die.",
+                    "",
+                    "I know an old lady who swallowed a dog.",
+                    "What a hog, to swallow a dog!",
+                    "She swallowed the dog to catch the cat.",
+                    "She swallowed the cat to catch the bird.",
+                    "She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.",
+                    "She swallowed the spider to catch the fly.",
+                    "I don't know why she swallowed the fly. Perhaps she'll die.",
+                    "",
+                    "I know an old lady who swallowed a goat.",
+                    "Just opened her throat and swallowed a goat!",
+                    "She swallowed the goat to catch the dog.",
+                    "She swallowed the dog to catch the cat.",
+                    "She swallowed the cat to catch the bird.",
+                    "She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.",
+                    "She swallowed the spider to catch the fly.",
+                    "I don't know why she swallowed the fly. Perhaps she'll die.",
+                    "",
+                    "I know an old lady who swallowed a cow.",
+                    "I don't know how she swallowed a cow!",
+                    "She swallowed the cow to catch the goat.",
+                    "She swallowed the goat to catch the dog.",
+                    "She swallowed the dog to catch the cat.",
+                    "She swallowed the cat to catch the bird.",
+                    "She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.",
+                    "She swallowed the spider to catch the fly.",
+                    "I don't know why she swallowed the fly. Perhaps she'll die.",
+                    "",
+                    "I know an old lady who swallowed a horse.",
+                    "She's dead, of course!"
+                ]
+            }
+        ]
+    }
+}

--- a/food-chain.json
+++ b/food-chain.json
@@ -1,8 +1,10 @@
 {
     "#": [
+        "JSON doesn't allow for multi-line strings, so all verses are presented ",
+        "here as arrays of strings. It's up to the test generator to join the ", 
+        "lines together with line breaks.",
         "Some languages test for the verse() method, which takes a start verse ",
-        "and optional end verse.",
-        "But other languages have only tested for the full poem.",
+        "and optional end verse, but other languages have only tested for the full poem.",
         "For those languages in the latter category, you may wish to only ",
         "implement the full song test and leave the rest alone, ignoring the start ",
         "and end verse fields."


### PR DESCRIPTION
Attempt to fix exercism/todo#91.

As noted in the JSON itself, half the languages that implement this exercise test a `verse` method while the other half only test for the full song. 

I decided to split the difference by putting both the verses and the full song in the JSON. If an exercise only wants the full song, its generator can just grab the `full song` test data, ignore the start/end verse, and get down to business.