### PR TITLE
sum-of-multiples: Clarifying problem

### DIFF
--- a/sum-of-multiples.md
+++ b/sum-of-multiples.md
@@ -1,7 +1,7 @@
-If we list all the natural numbers up to but not including 15 that are
-multiples of either 3 or 5, we get 3, 5, 6 and 9, 10, and 12.
+If we list all the natural numbers up to but not including 20 that are
+multiples of either 3 or 5, we get 3, 5, 6 and 9, 10, 12, 15, and 18.
 
-The sum of these multiples is 45.
+The sum of these multiples is 78.
 
 Write a program that can find the sum of the multiples of a given set of
-numbers.
+numbers. If no set of numbers is given, default to 3 and 5.


### PR DESCRIPTION
I just ran into this problem and got severely confused. The only way I figured out that the default behavior is to use `[3,5]` was by looking at an example solution, so I added a line making it explicit.

I also change the example to include a multiple of both 3 and 5. I thought this would be a nice hint that the list should be unique.