### PR TITLE
simple-linked-list: update Ruby example to include null object pattern

### DIFF
--- a/simple-linked-list.md
+++ b/simple-linked-list.md
@@ -20,20 +20,3 @@ linked list and convert to and from arrays.
 
 When implementing this in a language with built-in linked lists,
 implement your own abstract data type.
-
-Examples (Ruby):
-
-    Element.to_a(nil) #=> []
-    Element.from_a([]) #=> nil
-    Element.reverse(nil) #=> nil
-    one = Element.new(1, nil)
-    one #=> <Element @datum=1, @next=nil>
-    one.datum #=> 1
-    one.next #=> nil
-    two = Element.new(2, one)
-    two #=> <Element @datum=2, @next=<Element @datum=1 @next=nil>>
-    Element.to_a(two) #=> [2, 1]
-    Element.reverse(two) #=> <Element @datum=1 @next=<Element @datum=2 @next=nil>>
-    range = Element.from_a(1..10)
-    range.datum #=> 1
-    range.next.next.next.next.next.next.next.next.next.next.datum #=> 10


### PR DESCRIPTION
In the simple-linked-list README we have the following example Ruby code:
~~~ruby
Element.to_a(nil) #=> []
Element.from_a([]) #=> nil
Element.reverse(nil) #=> nil
one = Element.new(1, nil)
one #=> <Element @datum=1, @next=nil>
one.datum #=> 1
one.next #=> nil
two = Element.new(2, one)
two #=> <Element @datum=2, @next=<Element @datum=1 @next=nil>>
Element.to_a(two) #=> [2, 1]
Element.reverse(two) #=> <Element @datum=1 @next=<Element @datum=2 @next=nil>>
range = Element.from_a(1..10)
range.datum #=> 1
range.next.next.next.next.next.next.next.next.next.next.datum #=> 10
~~~

However in `simple_linked_list_test.rb` we have the following test:
~~~ruby
  def test_empty_list_operations
    skip
    assert_equal [], Element.from_a([]).to_a
    assert_equal [], Element.from_a([]).reverse.to_a
  end
~~~

The issue of the linked-list returning `nil` was addressed in [this commit](https://github.com/exercism/xruby/commit/fa6366e6f8a41da170205c0df6bd69fbf6d1e2ed), so I figured the Ruby code in the README should be updated to reflect that.