### PR TITLE
secret-handshake: added test json

### DIFF
--- a/secret-handshake.json
+++ b/secret-handshake.json
@@ -1,0 +1,142 @@
+{
+    "#": [
+        "The exercise only lays out the \"commands\" method,", 
+        "but some language tracks have tested reversing the translation and",
+        "composing the two functions, as well.",
+        "Consider the sets not under \"commands\" to be optional."
+    ],
+    "commands": {
+        "description": ["Create a handshake for a number"],
+        "cases": [
+            {
+                "description": "shake for 1",
+                "input": 1,
+                "expected": ["wink"]
+            },
+            {
+                "description": "shake for 10",
+                "input": 2,
+                "expected": ["double blink"]
+            },
+            {
+                "description": "shake for 100",
+                "input": 4,
+                "expected": ["close your eyes"]
+            },
+            {
+                "description": "shake for 1000",
+                "input": 8,
+                "expected": ["jump"]
+            },
+            {
+                "description": "shake for 11",
+                "input": 3,
+                "expected": ["wink", "double blink"]
+            },
+            {
+                "description": "shake for 11 reversed",
+                "input": 19,
+                "expected": ["double blink", "wink"]
+            },
+            {
+                "description": "shake for all",
+                "input": 16,
+                "expected": ["wink", "double blink", "close your eyes", "jump"]
+            },
+            {
+                "description": "shake for all reversed",
+                "input": 31,
+                "expected": ["jump", "close your eyes", "double blink", "wink"]
+            },
+            {
+                "description": "shake for binary",
+                "input": "101",
+                "expected": ["wink", "close your eyes"]
+            },
+            {
+                "description": "shake for reversed binary",
+                "input": "10110",
+                "expected": ["close your eyes", "double blink"]
+            },
+            {
+                "description": "invalid binary",
+                "input": "121",
+                "expected": []
+            },
+            {
+                "description": "shake for 0",
+                "input": 0,
+                "expected": []
+            },
+            {
+                "description": "shake for negative",
+                "input": -1,
+                "expected": []
+            },
+            {
+                "description": "too big",
+                "input": 32,
+                "expected": []
+            },
+            {
+                "description": "invalid string",
+                "input": "piggies",
+                "expected": []
+            },
+            {
+                "description": "invalid with numbers",
+                "input": "1piggies",
+                "expected": []
+            }
+        ]
+    },
+    "decode": {
+        "description": ["Decode a handshake to binary"],
+        "cases": [
+            {
+                "description": "decode big",
+                "actions": ["close your eyes", "jump"],
+                "expected": "1100"
+            },
+            {
+                "description": "decode small",
+                "actions": ["wink", "double blink"],
+                "expected": "11"
+            },
+            {
+                "description": "decode reversed",
+                "actions": ["jump", "double blink"],
+                "expected": "11010"
+            },
+            {
+                "description": "unknown action",
+                "actions": ["wink", "sneeze"],
+                "expected": "0"
+            }
+        ]
+    },
+    "composition": {
+        "description": [
+            "These tests check that running a number through commands and then",
+            "through decode will get you the binary equivalent. Or, if the number",
+            "already is binary, you just get the number back."
+        ],
+        "cases": [
+            {
+                "description": "reversed list",
+                "input": 27,
+                "expected": "11011"
+            },
+            {
+                "description": "one",
+                "input": 1,
+                "expected": "1"
+            },
+            {
+                "description": "111",
+                "input": "111",
+                "expected": "111"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Fixing exercism/todo#145. As mentioned in the ticket, I've created a couple different data sets to cover the tests in the python track.
