### PR TITLE
largest-series-product: Comment on tricky cases

### DIFF
--- a/largest-series-product.json
+++ b/largest-series-product.json
@@ -86,12 +86,30 @@
             "expected": -1
         },
         {
+            "#": [
+              "There may be some confusion about whether this should be 1 or error.",
+              "The reasoning for it being 1 is this:",
+              "There is one 0-character string contained in the empty string.",
+              "That's the empty string itself.",
+              "The empty product is 1 (the identity for multiplication).",
+              "Therefore LSP('', 0) is 1.",
+              "It's NOT the case that LSP('', 0) takes max of an empty list.",
+              "So there is no error.",
+              "Compare against LSP('123', 4):",
+              "There are zero 4-character strings in '123'.",
+              "So LSP('123', 4) really DOES take the max of an empty list.",
+              "So LSP('123', 4) errors and LSP('', 0) does NOT."
+            ],
             "description": "reports 1 for empty string and empty product (0 span)",
             "digits": "",
             "span": 0,
             "expected": 1
         },
         {
+            "#": [
+              "As above, there is one 0-character string in '123'.",
+              "So again no error. It's the empty product, 1."
+            ],
             "description": "reports 1 for nonempty string and empty product (0 span)",
             "digits": "123",
             "span": 0,


### PR DESCRIPTION
Cases involving 0 spans are understandably tricky. Some have argued that
LSP('', 0) should be an error because it takes the max of an empty list.
An example is https://github.com/exercism/xclojure/issues/49.

I agree that taking the max of an empty list is zero.
I disagree that LSP('', 0) takes the max of an empty list.

There is exactly one 0-character string in the empty string (or any
other string), that being the empty string.
The product of that is 1, as the identity element of multiplication.

Since there is reasonable chance for confusion, it is best to add
explanatory comments.