### PR TITLE
octal: Remove Ruby-specific terms

### DIFF
--- a/octal.yml
+++ b/octal.yml
@@ -1,5 +1,5 @@
 ---
-blurb: "Write a program that will convert a octal number, represented as a string (e.g. '1735263'), to its decimal equivalent using first principles (i.e. no, you may not use built-in ruby libraries or gems to accomplish the conversion)."
+blurb: "Write a program that will convert a octal number, represented as a string (e.g. '1735263'), to its decimal equivalent using first principles (i.e. no, you may not use built-in or external libraries to accomplish the conversion)."
 source: "All of Computer Science"
 source_url: "http://www.wolframalpha.com/input/?i=base+8"
 


### PR DESCRIPTION
These descriptions need to be language-agnostic since they are shown for
each language. #100 did the same for hexadecimal.