### PR TITLE
Update linked-list to remove outdated instructions

### DIFF
--- a/linked-list.md
+++ b/linked-list.md
@@ -22,13 +22,3 @@ conditions. Specifically: `pop` or `shift` will never be called on an
 empty list.
 
 If you want to know more about linked lists, check [Wikipedia](https://en.wikipedia.org/wiki/Linked_list).
-
----
-
-In languages that do not have good support for mutability (such as
-Elixir or Erlang), you may choose to implement a functional list where
-shift and pop have amortized O(1) time. The simplest data structure for
-this will have a pair of linked lists for the front and back, where
-iteration order is front ++ reverse back.
-
-


### PR DESCRIPTION
This is an addition to pull request #188 which has already been merged. As mentioned by @NobbZ there and in issue #193, the track specific instructions for Elixir and Erlang mentioned an incorrect alternative solution. 

I left these instructions in during the rewrite because I wasn't sure how relevant or important they were for those tracks.

This PR removes the outdated/incorrect paragraph.
