### PR TITLE
Fix typo of 'Caeser' in simple-cipher

### DIFF
--- a/simple-cipher.md
+++ b/simple-cipher.md
@@ -12,8 +12,8 @@ text less readable while still allowing easy deciphering. They are
 vulnerable to many forms of cryptoanalysis, but we are lucky that
 generally our little sisters are not cryptoanalysts.
 
-The Caeser Cipher was used for some messages from Julius Caesar that
-were sent afield. Now Caeser knew that the cipher wasn't very good, but
+The Caesar Cipher was used for some messages from Julius Caesar that
+were sent afield. Now Caesar knew that the cipher wasn't very good, but
 he had one ally in that respect: almost nobody could read well. So even
 being a couple letters off was sufficient so that people couldn't
 recognize the few words that they did know.


### PR DESCRIPTION
There are two instances of 'Caeser' in `simple-cipher`. This PR changes the typos to 'Caesar'.