### PR TITLE
series, largest-series-product: clarify "consecutive"

### DIFF
--- a/largest-series-product.md
+++ b/largest-series-product.md
@@ -1,6 +1,9 @@
-For example, for the input `'0123456789'`, the largest product for a
-series of 3 digits is 504 (7 * 8 * 9), and the largest product for a
-series of 5 digits is 15120 (5 * 6 * 7 * 8 * 9).
+For example, for the input `'1027839564'`, the largest product for a
+series of 3 digits is 270 (9 * 5 * 6), and the largest product for a
+series of 5 digits is 7560 (7 * 8 * 3 * 9 * 5).
+
+Note that these series are only required to occupy *adjacent positions*
+in the input; the digits need not be *numerically consecutive*.
 
 For the input `'73167176531330624919225119674426574742355349194934'`,
 the largest product for a series of 6 digits is 23520.

--- a/largest-series-product.yml
+++ b/largest-series-product.yml
@@ -1,4 +1,4 @@
 ---
-blurb: "Write a program that, when given a string of digits, can calculate the largest product for a series of consecutive digits of length n."
+blurb: "Write a program that, when given a string of digits, can calculate the largest product for a contiguous substring of digits of length n."
 source: "A variation on Problem 8 at Project Euler"
 source_url: "http://projecteuler.net/problem=8"

--- a/series.md
+++ b/series.md
@@ -1,13 +1,16 @@
-For example, the string "01234" has the following 3-digit series:
+For example, the string "49142" has the following 3-digit series:
 
-- 012
-- 123
-- 234
+- 491
+- 914
+- 142
 
 And the following 4-digit series:
 
-- 0123
-- 1234
+- 4914
+- 9142
 
 And if you ask for a 6-digit series from a 5-digit string, you deserve
 whatever you get.
+
+Note that these series are only required to occupy *adjacent positions*
+in the input; the digits need not be *numerically consecutive*.

--- a/series.yml
+++ b/series.yml
@@ -1,4 +1,4 @@
 ---
-blurb: "Write a program that will take a string of digits and give you all the possible consecutive number series of length `n` in that string."
+blurb: "Write a program that will take a string of digits and give you all the contiguous substrings of length `n` in that string."
 source: "A subset of the Problem 8 at Project Euler"
 source_url: "http://projecteuler.net/problem=8"


### PR DESCRIPTION
It was unclear whether "consecutive" meant consecutive in *numerical
value* or simply *positionally adjacent*. Due to this problem's origin
in Project Euler, it was the latter.

To avoid any confusion this commit does the following:
* Replace the word "consecutive" in .yml files with "contiguous"
* Clarifies in the .md files that the series of digits only need be
  positionally adjacent, not consecutive in numerical value.
* Uses examples in .md files that should make clear that numerical value
  is not important.

This should prevent any further confusion of the form expressed in the
two issues

* https://github.com/exercism/xruby/issues/244
* https://github.com/exercism/xruby/issues/262

This is the first subtask of #197.