### PR TITLE
Edit README to clarify exercise instructions (crypto-square)

### DIFF
--- a/crypto-square.md
+++ b/crypto-square.md
@@ -1,4 +1,7 @@
-The input is first normalized: The spaces and punctuation are removed
+Write a program that, given an English text, outputs the encoded version
+of that text.
+
+First, the input is normalized: the spaces and punctuation are removed
 from the English text and the message is downcased.
 
 Then, the normalized characters are broken into rows.  These rows can be
@@ -6,13 +9,19 @@ regarded as forming a rectangle when printed with intervening newlines.
 
 For example, the sentence
 
-> If man was meant to stay on the ground god would have given us roots
+> If man was meant to stay on the ground, god would have given us roots.
 
-is 54 characters long.
+is normalized to:
 
-Broken into 8-character columns, it yields 7 rows.
+> ifmanwasmeanttostayonthegroundgodwouldhavegivenusroots
 
-Those 7 rows produce this rectangle when printed one per line:
+The plaintext should be organized in to a rectangle.  The size of the
+rectangle (`r x c`) should be decided by the length of the message,
+such that `c >= r` and `c - r <= 1`, where `c` is the number of columns
+and `r` is the number of rows.
+
+Our normalized text is 54 characters long, dictating a rectangle with
+`c = 8` and `r = 7`:
 
 ```plain
 ifmanwas
@@ -27,43 +36,30 @@ sroots
 The coded message is obtained by reading down the columns going left to
 right.
 
-For example, the message above is coded as:
+The message above is coded as:
+
+```plain
+imtgdvsfearwermayoogoanouuiontnnlvtwttddesaohghnsseoau
+```
+
+Output the encoded text in chunks.  Phrases that fill perfect squares
+`(r X r)` should be output in `r`-length chunks separated by spaces.
+Imperfect squares will have `n` empty spaces.  Those spaces should be distributed evenly across the last `n` rows.
 
 ```plain
 imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn sseoau
 ```
 
-Write a program that, given an English text, outputs the encoded version
-of that text.
+Notice that were we to stack these, we could visually decode the
+cyphertext back in to the original message:
 
-The size of the square (number of columns) should be decided by the
-length of the message.
-
-If the message is a length that creates a perfect square (e.g. 4, 9, 16,
-25, 36, etc), use that number of columns.
-
-If the message doesn't fit neatly into a square, choose the number of
-columns that corresponds to the smallest square that is larger than the
-number of characters in the message.
-
-For example, a message 4 characters long should use a 2 x 2 square. A
-message that is 81 characters long would use a square that is 9 columns
-wide.
-
-A message between 5 and 8 characters long should use a rectangle 3
-characters wide.
-
-Output the encoded text grouped by column.
-
-For example:
-
-- "Have a nice day. Feed the dog & chill out!"
-  - Normalizes to: "haveanicedayfeedthedogchillout"
-  - Which has length: 30
-  - And splits into 5 6-character rows:
-    - "havean"
-    - "iceday"
-    - "feedth"
-    - "edogch"
-    - "illout"
-  - Which yields a ciphertext beginning: "hifei acedl v…"
+```plain
+imtgdvs
+fearwer
+mayoogo
+anouuio
+ntnnlvt
+wttddes
+aohghn
+sseoau
+```


### PR DESCRIPTION
This PR is to address #190 .  

@petertseng asked if the output should be chunked.  My opinion, shared with @jtigger,  is that it should be, as it was in the original exercise that inspired this problem, and chunking the output fits aesthetically with the idea of creating a visual 'square' which is what the original users of this method would have done.

We're hoping we can get some consensus on the content of the README, then as a next step add a `config.json` for this exercise.  Thanks all!

