### PR TITLE
Add additional equality test to clock exercise

### DIFF
--- a/clock.json
+++ b/clock.json
@@ -247,6 +247,18 @@
                "minute": 37
             },
             "expected": true
+         },
+         {
+            "description": "clocks with minute overflow",
+            "clock1": {
+               "hour": 0,
+               "minute": 1
+            },
+            "clock2": {
+               "hour": 0,
+               "minute": 1441
+            },
+            "expected": true
          }
       ]
    }


### PR DESCRIPTION
The existing test suite was not rigorous enough in testing the equality
of two clock values. Specifically, it was unable to compare two clocks
where the times were offset by 24 hours. For example,

clock{0, 1}
clock{0, 1441}

Since there are 1440 minutes in a 24 hour period, the time on the second
clock should be wrapped around, making it equal to the first.

This new test will catch this situation.