### PR TITLE
Add sum-of-multiples.json

### DIFF
--- a/sum-of-multiples.json
+++ b/sum-of-multiples.json
@@ -1,0 +1,64 @@
+{
+    "cases": [
+        {
+            "factors": [3, 5],
+            "limit": 1,
+            "expected": 0
+        },
+        {
+            "factors": [3, 5],
+            "limit": 4,
+            "expected": 3
+        },
+        {
+            "factors": [3, 5],
+            "limit": 10,
+            "expected": 23
+        },
+        {
+            "factors": [3, 5],
+            "limit": 100,
+            "expected": 2318
+        },
+        {
+            "factors": [3, 5],
+            "limit": 1000,
+            "expected": 233168
+        },
+        {
+            "factors": [7, 13, 17],
+            "limit": 20,
+            "expected": 51
+        },
+        {
+            "factors": [4, 6],
+            "limit": 15,
+            "expected": 30
+        },
+        {
+            "factors": [5, 6, 8],
+            "limit": 150,
+            "expected": 4419
+        },
+        {
+            "factors": [5, 25],
+            "limit": 51,
+            "expected": 275
+        },
+        {
+            "factors": [43, 47],
+            "limit": 10000,
+            "expected": 2203160
+        },
+        {
+            "factors": [1],
+            "limit": 100,
+            "expected": 4950
+        },
+        {
+            "factors": [],
+            "limit": 10000,
+            "expected": 0
+        }
+    ]
+}


### PR DESCRIPTION
This is a synthesis of the existing tests in current tracks.

A short attempt to discern the history of the various tests:

Almost all tracks have the [3, 5] cases in common, as well as the
[7, 13, 17] and [43, 47] case. Indeed, these cases were present since
the first known sighting of sum-of-multiples at
https://github.com/exercism/exercism.io/commit/607be68494d30487c001303b6dc56c2b7b975409.

The [3, 5] to 100 case was added after discussion in
https://github.com/exercism/todo/issues/20 and
https://github.com/exercism/exercism.io/issues/2486. Most tracks had
adopted them at the time of this PR.

The [4, 6] and [5, 6, 8] cases arose from discussion in
https://github.com/exercism/exercism.io/issues/2341 - some tracks, but
not all, had adopted these tests at the time of this PR.

The [5, 25] case was a Haskell-specific case added in
https://github.com/exercism/xhaskell/pull/50.

The [] and [1] cases were Go-specific cases that have been present ever
since the exercise was added to the Go track in
https://github.com/exercism/xgo/pull/53.

Cases found in various tracks that were not included:

The [1] case of Go was originally a [1, 1] case but this is a conscious
decision not to test duplicate factors.

There were [0] and [0, 1] cases added to the Python track in
https://github.com/exercism/xpython/pull/149 but this is a conscious
decision not to test 0 as a factor.

This is the second subtask of #198.

Closes https://github.com/exercism/todo/issues/154