### PR TITLE
sum-of-multiples: Mark as no longer under revision

### DIFF
--- a/sum-of-multiples.md
+++ b/sum-of-multiples.md
@@ -5,15 +5,3 @@ The sum of these multiples is 78.
 
 Write a program that can find the sum of the multiples of a given set of
 numbers.
-
-This exercise is currently under revision.
-You are still free to do this exercise and submit solutions.
-Depending on whether this track has been updated recently,
-the tests may differ between this track and other tracks.
-
-In most tracks, the set of numbers must be explicitly provided.
-In some other tracks, if no set of numbers is given, it defaults to 3 and 5.
-We would like all tracks to require the set of numbers be explicit.
-
-If you would like to help out, please join us at
-https://github.com/exercism/x-common/issues/198.


### PR DESCRIPTION
This partially reverts 1f0ad90774e3922558c39f8aa3ccd81b83b1c99f,
which partially reverted 89308fd925b604e84fb652d8b72ee74ca231474b.

The default behavior was added in #157 as a result of confusion in
https://github.com/exercism/exercism.io/issues/2654. Since then, we have
decided the way forward is to remove the default behavior altogether, as
discussed in https://github.com/exercism/x-common/issues/198.

This commit should be held until all tracks have removed their
expectations of default behavior.