### PR TITLE
clock: add more test cases to canonical test data

### DIFF
--- a/clock.json
+++ b/clock.json
@@ -18,22 +18,10 @@
             "expected": "08:00"
          },
          {
-            "description": "on the hour",
-            "hour": 9,
-            "minute": 0,
-            "expected": "09:00"
-         },
-         {
             "description": "past the hour",
             "hour": 11,
             "minute": 9,
             "expected": "11:09"
-         },
-         {
-            "description": "past the hour",
-            "hour": 11,
-            "minute": 19,
-            "expected": "11:19"
          },
          {
             "description": "midnight is zero hours",
@@ -48,6 +36,12 @@
             "expected": "01:00"
          },
          {
+            "description": "hour rolls over continuously",
+            "hour": 100,
+            "minute": 0,
+            "expected": "04:00"
+         },
+         {
             "description": "sixty minutes is next hour",
             "hour": 1,
             "minute": 60,
@@ -60,10 +54,28 @@
             "expected": "02:40"
          },
          {
+            "description": "minutes roll over continuously",
+            "hour": 0,
+            "minute": 1723,
+            "expected": "04:43"
+         },
+         {
             "description": "hour and minutes roll over",
             "hour": 25,
             "minute": 160,
             "expected": "03:40"
+         },
+         {
+            "description": "hour and minutes roll over continuously",
+            "hour": 201,
+            "minute": 3001,
+            "expected": "11:01"
+         },
+         {
+            "description": "hour and minutes roll over to exactly midnight",
+            "hour": 72,
+            "minute": 8640,
+            "expected": "00:00"
          },
          {
             "description": "negative hour",
@@ -78,6 +90,12 @@
             "expected": "23:00"
          },
          {
+            "description": "negative hour rolls over continuously",
+            "hour": -91,
+            "minute": 0,
+            "expected": "05:00"
+         },
+         {
             "description": "negative minutes",
             "hour": 1,
             "minute": -40,
@@ -90,10 +108,22 @@
             "expected": "22:20"
          },
          {
+            "description": "negative minutes roll over continuously",
+            "hour": 1,
+            "minute": -4820,
+            "expected": "16:40"
+         },
+         {
             "description": "negative hour and minutes both roll over",
             "hour": -25,
             "minute": -160,
             "expected": "20:20"
+         },
+         {
+            "description": "negative hour and minutes both roll over continuously",
+            "hour": -121,
+            "minute": -5810,
+            "expected": "22:10"
          }
       ]
    },
@@ -110,6 +140,13 @@
             "expected": "10:03"
          },
          {
+            "description": "add no minutes",
+            "hour": 6,
+            "minute": 41,
+            "add": 0,
+            "expected": "06:41"
+         },
+         {
             "description": "add to next hour",
             "hour": 0,
             "minute": 45,
@@ -122,6 +159,13 @@
             "minute": 0,
             "add": 61,
             "expected": "11:01"
+         },
+         {
+            "description": "add more than two hours with carry",
+            "hour": 0,
+            "minute": 45,
+            "add": 160,
+            "expected": "03:25"
          },
          {
             "description": "add across midnight",
@@ -138,11 +182,11 @@
             "expected": "06:32"
          },
          {
-            "description": "add more than two hours with carry",
-            "hour": 0,
-            "minute": 45,
-            "add": 160,
-            "expected": "03:25"
+            "description": "add more than two days",
+            "hour": 1,
+            "minute": 1,
+            "add": 3500,
+            "expected": "11:21"
          },
          {
             "description": "subtract minutes",
@@ -180,6 +224,13 @@
             "expected": "21:20"
          },
          {
+            "description": "subtract more than two hours with borrow",
+            "hour": 6,
+            "minute": 15,
+            "add": -160,
+            "expected": "03:35"
+         },
+         {
             "description": "subtract more than one day (1500 min = 25 hrs)",
             "hour": 5,
             "minute": 32,
@@ -187,11 +238,11 @@
             "expected": "04:32"
          },
          {
-            "description": "subtract more than two hours with borrow",
-            "hour": 6,
-            "minute": 15,
-            "add": -160,
-            "expected": "03:35"
+            "description": "subtract more than two days",
+            "hour": 2,
+            "minute": 20,
+            "add": -3000,
+            "expected": "00:20"
          }
       ]
    },
@@ -237,7 +288,7 @@
             "expected": false
          },
          {
-            "description": "clocks set 24 hours apart",
+            "description": "clocks with hour overflow",
             "clock1": {
                "hour": 10,
                "minute": 37
@@ -245,6 +296,54 @@
             "clock2": {
                "hour": 34,
                "minute": 37
+            },
+            "expected": true
+         },
+         {
+            "description": "clocks with hour overflow by several days",
+            "clock1": {
+               "hour": 3,
+               "minute": 11
+            },
+            "clock2": {
+               "hour": 99,
+               "minute": 11
+            },
+            "expected": true
+         },
+         {
+            "description": "clocks with negative hour",
+            "clock1": {
+               "hour": 22,
+               "minute": 40
+            },
+            "clock2": {
+               "hour": -2,
+               "minute": 40
+            },
+            "expected": true
+         },
+         {
+            "description": "clocks with negative hour that wraps",
+            "clock1": {
+               "hour": 17,
+               "minute": 3
+            },
+            "clock2": {
+               "hour": -31,
+               "minute": 3
+            },
+            "expected": true
+         },
+         {
+            "description": "clocks with negative hour that wraps multiple times",
+            "clock1": {
+               "hour": 13,
+               "minute": 49
+            },
+            "clock2": {
+               "hour": -83,
+               "minute": 49
             },
             "expected": true
          },
@@ -257,6 +356,78 @@
             "clock2": {
                "hour": 0,
                "minute": 1441
+            },
+            "expected": true
+         },
+         {
+            "description": "clocks with minute overflow by several days",
+            "clock1": {
+               "hour": 2,
+               "minute": 2
+            },
+            "clock2": {
+               "hour": 2,
+               "minute": 4322
+            },
+            "expected": true
+         },
+         {
+            "description": "clocks with negative minute",
+            "clock1": {
+               "hour": 2,
+               "minute": 40
+            },
+            "clock2": {
+               "hour": 3,
+               "minute": -20
+            },
+            "expected": true
+         },
+         {
+            "description": "clocks with negative minute that wraps",
+            "clock1": {
+               "hour": 4,
+               "minute": 10
+            },
+            "clock2": {
+               "hour": 5,
+               "minute": -1490
+            },
+            "expected": true
+         },
+         {
+            "description": "clocks with negative minute that wraps multiple times",
+            "clock1": {
+               "hour": 6,
+               "minute": 15
+            },
+            "clock2": {
+               "hour": 6,
+               "minute": -4305
+            },
+            "expected": true
+         },
+         {
+            "description": "clocks with negative hours and minutes",
+            "clock1": {
+               "hour": 7,
+               "minute": 32
+            },
+            "clock2": {
+               "hour": -12,
+               "minute": -268
+            },
+            "expected": true
+         },
+         {
+            "description": "clocks with negative hours and minutes that wrap",
+            "clock1": {
+               "hour": 18,
+               "minute": 7
+            },
+            "clock2": {
+               "hour": -54,
+               "minute": -11513
             },
             "expected": true
          }


### PR DESCRIPTION
In the Go track I've seen a lot of people who only account for a clock
overflowing once in either direction. As the README describes the
problem, any overflow should be corrected, even if it accounts for
several days.

The second problem that I've seen a lot is people who adjust in the
display method, which means that the clocks would fail the equality
check. We weren't verifying equality against overflow, however, so we
didn't catch this.

I also removed two redundant test cases.