### PR TITLE
rna-transcription: remove rna->dna cases from canonical data

### DIFF
--- a/rna-transcription.json
+++ b/rna-transcription.json
@@ -14,7 +14,7 @@
    "cases": [
       {
          "description": "rna complement of cytosine is guanine",
-         "dna" : "C", 
+         "dna" : "C",
          "expected": "G"
       },
       {
@@ -37,39 +37,9 @@
          "dna": "ACGTGGTCTTAA",
          "expected": "UGCACCAGAAUU"
       },
-         {
-         "description": "dna complement of cytosine is guanine",
-         "rna" : "C", 
-         "expected": "G"
-      },
-      {
-         "description": "dna complement of guanine is cytosine",
-         "rna": "G",
-         "expected": "C"
-      },
-      {
-         "description": "dna complement of uracil is adenine",
-         "rna": "U",
-         "expected": "A"
-      },
-      {
-         "description": "dna complement of adenine is thymine",
-         "rna": "A",
-         "expected": "T"
-      },
-      {
-         "description": "dna complement",
-         "rna": "UGAACCCGACAUG",
-         "expected": "ACTTGGGCTGTAC"
-      },
       {
          "description": "dna correctly handles invalid input",
          "dna": "U",
-         "expected": null
-      },
-      {
-         "description": "rna correctly handles invalid input",
-         "rna": "T",
          "expected": null
       },
       {
@@ -78,18 +48,8 @@
          "expected": null
       },
       {
-         "description": "rna correctly handles completely invalid input",
-         "rna": "XXX",
-         "expected": null
-      },
-      {
          "description": "dna correctly handles partially invalid input",
          "dna": "ACGTXXXCTTAA",
-         "expected": null
-      },
-      {
-         "description": "rna correctly handles partially invalid input",
-         "rna": "UGAAXXXGACAUG",
          "expected": null
       }
    ]


### PR DESCRIPTION
There is no biological basis for RNA->DNA transcription.

A couple of people suggested that we could rephrase this and make the
question _Given this RNA, what DNA sequence could produce it?_, but
it seemed simpler to simply remove it.

There is also the question of whether or not having the reverse
transcription helps guide people to a better/more generic solution.
I think that this is one place where we could have the discussion on the
website about hard-coding vs not.

See https://github.com/exercism/x-common/issues/148