### PR TITLE
add pangram tests

### DIFF
--- a/pangram.json
+++ b/pangram.json
@@ -16,6 +16,26 @@
         "expected": false
       },
       {
+        "description": "another missing character 'x'",
+        "input": "the quick brown fish jumps over the lazy dog",
+        "expected": false
+      },
+      {
+        "description": "pangram with underscores",
+        "input": "the_quick_brown_fox_jumps_over_the_lazy_dog",
+        "expected": true
+      },
+      {
+        "description": "pangram with numbers",
+        "input": "the 1 quick brown fox jumps over the 2 lazy dogs",
+        "expected": true
+      },
+      {
+        "description": "missing letters replaced by numbers",
+        "input": "7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog",
+        "expected": false
+      },
+      {
         "description": "pangram with mixed case and punctuation",
         "input": "\"Five quacking Zephyrs jolt my wax bed.\"",
         "expected": true


### PR DESCRIPTION
this commit adds 3 total tests

- adds a non-pangram to resolve #222
- adds a pangram with underscores
- adds a non-pangram where some letters have been replaced by numbers

the latter two are designed to detect solutions that rely on counting
the number of word characters (which include numbers and underscoe)