### PR TITLE
sum-of-multiples: Note change in flight in README

### DIFF
--- a/sum-of-multiples.md
+++ b/sum-of-multiples.md
@@ -4,4 +4,16 @@ multiples of either 3 or 5, we get 3, 5, 6 and 9, 10, 12, 15, and 18.
 The sum of these multiples is 78.
 
 Write a program that can find the sum of the multiples of a given set of
-numbers. If no set of numbers is given, default to 3 and 5.
+numbers.
+
+This exercise is currently under revision.
+You are still free to do this exercise and submit solutions.
+Depending on whether this track has been updated recently,
+the tests may differ between this track and other tracks.
+
+In most tracks, the set of numbers must be explicitly provided.
+In some other tracks, if no set of numbers is given, it defaults to 3 and 5.
+We would like all tracks to require the set of numbers be explicit.
+
+If you would like to help out, please join us at
+https://github.com/exercism/x-common/issues/198.


### PR DESCRIPTION
As noted in https://github.com/exercism/discussions/issues/2, while #198
to remove the [3, 5] defaults is in flight, we should mark it as such in
the README.

This avoids confusion in the form of "Oh, this track doesn't implement
the defaults in the README, so I'll add them", reversing the work we've
done to make the exercise consistent across all tracks.