### PR TITLE
Implement canonical dataset for scrabble-score problem

### DIFF
--- a/scrabble-score.json
+++ b/scrabble-score.json
@@ -1,0 +1,49 @@
+{
+  "cases": [
+    {
+      "description": "lowercase letter",
+      "input": "a",
+      "expected": 1
+    },
+    {
+      "description": "uppercase letter",
+      "input": "A",
+      "expected": 1
+    },
+    {
+      "description": "valuable letter",
+      "input": "f",
+      "expected": 4
+    },
+    {
+      "description": "short word",
+      "input": "at",
+      "expected": 2
+    },
+    {
+      "description": "short, valuable word",
+      "input": "zoo",
+      "expected": 12
+    },
+    {
+      "description": "medium word",
+      "input": "street",
+      "expected": 6
+    },
+    {
+      "description": "medium, valuable word",
+      "input": "quirky",
+      "expected": 22
+    },
+    {
+      "description": "long, mixed-case word",
+      "input": "OxyphenButazone",
+      "expected": 41
+    },
+    {
+      "description": "empty input",
+      "input": "",
+      "expected": 0
+    }
+  ]
+}

--- a/scrabble-score.json
+++ b/scrabble-score.json
@@ -41,6 +41,16 @@
       "expected": 41
     },
     {
+      "description": "english-like word",
+      "input": "pinata",
+      "expected": 8
+    },
+    {
+      "description": "non-english letter is not scored",
+      "input": "piñata",
+      "expected": 7
+    },
+    {
       "description": "empty input",
       "input": "",
       "expected": 0


### PR DESCRIPTION
This supersedes PR #161 (preserving the work done by @SwamWithTurtles, thereby giving credit where credit is due).

Question: Should we have a case that has punctuation (which should not be scored)?

I don't like that the description for the non-English letter is a sentence whereas all the others are sentence-fragments, but that's the only case where more explanation is needed, I think.