### PR TITLE
Reorder custom-set tests to improve flow

### DIFF
--- a/custom-set.json
+++ b/custom-set.json
@@ -47,29 +47,6 @@
          }
       ]
    },
-   "add": {
-      "description": "Unique elements can be added to a set",
-      "cases": [
-         {
-            "description": "add to empty set",
-            "set": [],
-            "element": 3,
-            "expected": [3]
-         },
-         {
-            "description": "add to non-empty set",
-            "set": [1, 2, 4],
-            "element": 3,
-            "expected": [1, 2, 3, 4]
-         },
-         {
-            "description": "adding an existing element does not change the set",
-            "set": [1, 2, 3],
-            "element": 3,
-            "expected": [1, 2, 3]
-         }
-      ]
-   },
    "subset": {
       "description": "A set is a subset if all of its elements are contained in the other set",
       "cases": [
@@ -146,6 +123,64 @@
          }
       ]
    },
+   "equal": {
+      "description": "Sets with the same elements are equal",
+      "cases": [
+         {
+            "description": "empty sets are equal",
+            "set1": [],
+            "set2": [],
+            "expected": true
+         },
+         {
+            "description": "empty set is not equal to non-empty set",
+            "set1": [],
+            "set2": [1, 2, 3],
+            "expected": false
+         },
+         {
+            "description": "non-empty set is not equal to empty set",
+            "set1": [1, 2, 3],
+            "set2": [],
+            "expected": false
+         },
+         {
+            "description": "sets with the same elements are equal",
+            "set1": [1, 2],
+            "set2": [2, 1],
+            "expected": true
+         },
+         {
+            "description": "sets with different elements are not equal",
+            "set1": [1, 2, 3],
+            "set2": [1, 2, 4],
+            "expected": false
+         }
+      ]
+   },
+   "add": {
+      "description": "Unique elements can be added to a set",
+      "cases": [
+         {
+            "description": "add to empty set",
+            "set": [],
+            "element": 3,
+            "expected": [3]
+         },
+         {
+            "description": "add to non-empty set",
+            "set": [1, 2, 4],
+            "element": 3,
+            "expected": [1, 2, 3, 4]
+         },
+         {
+            "description": "adding an existing element does not change the set",
+            "set": [1, 2, 3],
+            "element": 3,
+            "expected": [1, 2, 3]
+         }
+      ]
+   },
    "intersection": {
       "description": "Intersect returns a set of all shared elements",
       "cases": [
@@ -207,41 +242,6 @@
             "set1": [3, 2, 1],
             "set2": [2, 4],
             "expected": [1, 3]
-         }
-      ]
-   },
-   "equal": {
-      "description": "Sets with the same elements are equal",
-      "cases": [
-         {
-            "description": "empty sets are equal",
-            "set1": [],
-            "set2": [],
-            "expected": true
-         },
-         {
-            "description": "empty set is not equal to non-empty set",
-            "set1": [],
-            "set2": [1, 2, 3],
-            "expected": false
-         },
-         {
-            "description": "non-empty set is not equal to empty set",
-            "set1": [1, 2, 3],
-            "set2": [],
-            "expected": false
-         },
-         {
-            "description": "sets with the same elements are equal",
-            "set1": [1, 2],
-            "set2": [2, 1],
-            "expected": true
-         },
-         {
-            "description": "sets with different elements are not equal",
-            "set1": [1, 2, 3],
-            "set2": [1, 2, 4],
-            "expected": false
          }
       ]
    },


### PR DESCRIPTION
The goal of this change is to ensure that no tests that require set equality in an assertion precede the tests for set equality. This allows each set of tests to introduce as little new functionality as possible (assuming that tests are completed from top to bottom).

For example, the `add` tests assert set equality to determine whether `add` is implemented correctly, but these tests precede the `equal` tests which explicitly test the set equality method. Without this change, set equality and adding new elements to a set are both introduced in the `add` tests. After this change, the `equal` tests precede the `add` tests so that set equality is implemented prior to its use in the `add` tests.

Note that the `equal` tests were maintained below the `subset` tests to gently encourage set equality to be implemented using subsets (see https://github.com/exercism/x-common/pull/232).