### PR TITLE
Add canonical tests for Wordy

### DIFF
--- a/wordy.json
+++ b/wordy.json
@@ -1,0 +1,89 @@
+{
+  "#": [
+    "The tests that expect 'false' should be implemented to raise",
+    "an error, or indicate a failure. Implement this in a way that",
+    "makes sense for your language."
+  ],
+    "cases": [
+      {
+            "description": "addition",
+            "input": "What is 1 plus 1?",
+            "expected": 2
+      },
+      {
+            "description": "more addition",
+            "input": "What is 53 plus 2?",
+            "expected": 55
+      },
+      {
+            "description": "addition with negative numbers",
+            "input": "What is -1 plus -10?",
+            "expected": -11
+      },
+      {
+            "description": "large addition",
+            "input": "What is 123 plus 45678?",
+            "expected": 45801
+      },
+      {
+            "description": "subtraction",
+            "input": "What is 4 minus -12?",
+            "expected": 16
+      },
+      {
+            "description": "multiplication",
+            "input": "What is -3 multiplied by 25?",
+            "expected": -75
+      },
+      {
+            "description": "division",
+            "input": "What is 33 divided by -3?",
+            "expected": -11
+      },
+      {
+            "description": "multiple additions",
+            "input": "What is 1 plus 1 plus 1?",
+            "expected": 3
+      },
+      {
+            "description": "addition and subtraction",
+            "input": "What is 1 plus 5 minus -2?",
+            "expected": 8
+      },
+      {
+            "description": "multiple subtraction",
+            "input": "What is 20 minus 4 minus 13?",
+            "expected": 3
+      },
+      {
+            "description": "subtraction then addition",
+            "input": "What is 17 minus 6 plus 3?",
+            "expected": 14
+      },
+      {
+            "description": "multiple multiplication",
+            "input": "What is 2 multiplied by -2 multiplied by 3?",
+            "expected": -12
+      },
+      {
+            "description": "addition and multiplication",
+            "input": "What is -3 plus 7 multiplied by -2?",
+            "expected": -8
+      },
+      {
+            "description": "multiple division",
+            "input": "What is -12 divided by 2 divided by -3?",
+            "expected": 2
+      },
+      {
+            "description": "unknown operation",
+            "input": "What is 52 cubed?",
+            "expected": false
+      },
+      {
+            "description": "Non math question",
+            "input": "Who is the President of the United States?",
+            "expected": false
+      }
+    ]
+}


### PR DESCRIPTION
Currently 13 tracks implement this problem. The full list of each track's tests can be found [over at this gist](https://gist.github.com/IanWhitney/3fe2e8ca98d2c6ef37dccb313172f69b)

Of the 13, 11 tracks share the exact same test suite. Those are the tests that I have canonized in this json file.

Python and Scala each have their own tests. But the behavior under test is mostly the same.

Python checks for [some additional failure cases](https://github.com/exercism/xpython/blob/master/exercises/wordy/wordy_test.py#L52)

Scala [allows students to implement powers](https://github.com/exercism/xscala/blob/master/exercises/wordy/src/test/scala/WordProblemTest.scala#L63) as extra credit.

I can see putting some of the Python failure tests in here, but I wanted to get more feedback before making that change.