### PR TITLE
Adding Markdown refactoring exercise

### DIFF
--- a/markdown.json
+++ b/markdown.json
@@ -1,0 +1,62 @@
+{
+  "#": [
+    "Markdown is a shorthand for creating HTML from text strings."
+  ],
+  "methods": {
+    "description": [
+      "Check the public API is correct."
+    ],
+    "cases": [{
+      "description": "must be able to parse a Markdown string",
+      "method": "parse",
+      "arity": 1
+    }]
+  },
+  "cases": [
+    {
+       "description": "parses normal text as a paragraph",
+       "input": "This will be a paragraph",
+       "expected": "<p>This will be a paragraph</p>"
+    },
+    {
+      "description": "parsing italics",
+      "input": "_This will be italic_",
+      "expected": "<p><i>This will be italic</i></p>"
+    },
+    {
+      "description": "parsing bold text",
+      "input": "__This will be bold__",
+      "expected": "<p><em>This will be bold</em></p>"
+    },
+    {
+      "description": "mixed normal, italics and bold text",
+      "input": "This will _be_ __mixed__",
+      "expected": "<p>This will <i>be</i> <em>mixed</em></p>"
+    },
+    {
+      "description": "with h1 header level",
+      "input": "# This will be an h1",
+      "expected": "<h1>This will be an h1</h1>"
+    },
+    {
+      "description": "with h2 header level",
+      "input": "## This will be an h2",
+      "expected": "<h2>This will be an h2</h2>"
+    },
+    {
+      "description": "with h6 header level",
+      "input": "###### This will be an h6",
+      "expected": "<h6>This will be an h6</h6>"
+    },
+    {
+      "description": "unordered lists",
+      "input": "* Item 1\n* Item 2",
+      "expected": "<ul><li><p>Item 1</p></li><li><p>Item 2</p></li></ul>"
+    },
+    {
+      "description": "With a little bit of everything",
+      "input": "# Header!\n* __Bold Item__\n* _Italic Item_",
+      "expected": "<h1>Header!</h1><ul><li><em>Bold Item</em></li><li><i>Italic Item</i></li></ul>"
+    }
+  ]
+}

--- a/markdown.md
+++ b/markdown.md
@@ -1,0 +1,11 @@
+The markdown exercise is a refactoring exercise. There is code that parses a
+given string with [Markdown
+syntax](https://guides.github.com/features/mastering-markdown/) and returns the
+associated HTML for that string. Even though this code is confusingly written
+and hard to follow, somehow it works and all the tests are passing! Your
+challenge is to re-write this code to make it easier to read and maintain
+while still making sure that all the tests keep passing.
+
+It would be helpful if you made notes of what you did in your refactoring in
+comments so reviewers can see that, but it isn't strictly necessary. The most
+important thing is to make the code better!

--- a/markdown.yml
+++ b/markdown.yml
@@ -1,0 +1,2 @@
+---
+blurb: "Refactor a Markdown parser"


### PR DESCRIPTION
It would be great to have some more refactoring exercises, and one that is easy
to write both poorly and well is a Markdown parser. This is just the outline
for that, but it does include a pretty basic set of tests that cover a small
subset of Markdown syntax.

This is in response to the discussion [here](https://github.com/exercism/discussions/issues/24) about adding more refactoring
exercises.