### PR TITLE
Added an extra test for the isogram exercise. …

### DIFF
--- a/isogram.json
+++ b/isogram.json
@@ -26,5 +26,8 @@
   }, {
     "input": "Emily Jung Schwartzkopf",
     "expected": true
+  }, {
+    "input": "éléphant",
+    "expected": false
   }]
 }


### PR DESCRIPTION
This ensures that implementations that use a simple regex replace of non-word characters will not pass.

More specifically I initially used an implementation that looked like this:

```
val sanitizedInput = input.replace("\\W".toRegex(), "").toLowerCase()
return sanitizedInput.toSet().size == sanitizedInput.length
```

The reasoning for using this implementation was to remove the `-` and whitespace characters. 
The tests correctly passed, however I then realised that the Regex replace will replace non-ASCII chars as well (at least the JVM based Regex implementation) thus providing a 'false positive'

The new `éléphant` entry ensures that an implementation like the above will not pass.