### PR TITLE
“A” appears 14 times, doesn’t score 14 points

### DIFF
--- a/etl.md
+++ b/etl.md
@@ -37,5 +37,5 @@ transforms the legacy data format to the shiny new format.
 
 A final note about scoring, Scrabble is played around the world in a
 variety of languages, each with its own unique scoring table. For
-example, an "A" is scored at 14 in the Basque-language version of the
-game while being scored at 9 in the Latin-language version.
+example, an "E" is scored at 2 in the Māori-language version of the
+game while being scored at 4 in the Hawaiian-language version.


### PR DESCRIPTION
I might be misunderstanding this, but I believe this is an error.

Letter "A" doesn't score highly in Basque or Latin. If you check the [scoring tables on Wikipedia](https://en.wikipedia.org/wiki/Scrabble_letter_distributions), you'll see those numbers are the *frequency* of the letters. This is: letter "A" appears 14 times in the Basque version; still scores a single point.

I've been looking for other examples, bit it would appear only Pinyin Chinese scores more than 1 for an "A". I have altered the examples to be about letter "E" instead.