### PR TITLE
removes an elixir specific clause that is not necessary

### DIFF
--- a/accumulate.md
+++ b/accumulate.md
@@ -18,8 +18,5 @@ Keep your hands off that collect/map/fmap/whatchamacallit functionality
 provided by your standard library!
 Solve this one yourself using other basic tools instead.
 
-Elixir specific: it's perfectly fine to use `Enum.reduce` or
-`Enumerable.reduce`.
-
 Lisp specific: it's perfectly fine to use `MAPCAR` or the equivalent,
 as this is idiomatic Lisp, not a library function.


### PR DESCRIPTION
As shown in the [example solution](https://github.com/exercism/xelixir/blob/master/exercises/accumulate/example.exs) it can be done in Elixir without using a named module, like Enum.reduce. In fact its probably confusing to suggest so. 