### PR TITLE
Remove track specific wording from triangle readme

### DIFF
--- a/triangle.md
+++ b/triangle.md
@@ -1,7 +1,5 @@
 The program should raise an error if the triangle cannot exist.
 
-Tests are provided, delete one `skip` at a time.
-
 ## Hint
 
 The sum of the lengths of any two sides of a triangle always exceeds the


### PR DESCRIPTION
We had a confused user of the Elm track because elm-test does not have a "skip" concept (https://github.com/exercism/xelm/issues/66). It seems to me that this sort of instruction would be more suitable as a comment in the test file for now.

The other option might be just qualify this note a bit.