### PR TITLE
Explicitly describe robot name format

### DIFF
--- a/robot-name.md
+++ b/robot-name.md
@@ -1,7 +1,7 @@
 When robots come off the factory floor, they have no name.
 
-The first time you boot them up, a random name is generated, such as
-RX837 or BC811.
+The first time you boot them up, a random name is generated in the format
+of two uppercase letters followed by three digits, such as RX837 or BC811.
 
 Every once in a while we need to reset a robot to its factory settings,
 which means that their name gets wiped. The next time you ask, it will


### PR DESCRIPTION
The definition of this problem led to some confusion in the scala exercise's test case. Some languages have exercises that expect differing formats for the robots names. This is an attempt to make it explicit and clear to the end-users and the exercise creators to avoid this ambiguity.

An example of this issue can be found in this PR: https://github.com/exercism/xscala/pull/123

If this PR is accepted, I will be more than happy to check the languages that have the "Robot Name" problem to make sure the tests for the "Robot Name" exercises are consistent.