### PR TITLE
tournament: Add JSON file

### DIFF
--- a/tournament.json
+++ b/tournament.json
@@ -1,0 +1,88 @@
+{
+  "#": [
+    "The inputs and outputs are represented as arrays of strings to improve readability in this JSON file.",
+    "Your track may choose whether to present the input as a single string (concatenating all the lines) or as the list.",
+    "In most cases, it seems to make sense to expect the output as a single string."
+  ],
+  "valid_inputs": {
+    "cases": [
+      {
+        "description": "typical input",
+        "input": [
+          "Allegoric Alaskans;Blithering Badgers;win",
+          "Devastating Donkeys;Courageous Californians;draw",
+          "Devastating Donkeys;Allegoric Alaskans;win",
+          "Courageous Californians;Blithering Badgers;loss",
+          "Blithering Badgers;Devastating Donkeys;loss",
+          "Allegoric Alaskans;Courageous Californians;win"
+        ],
+        "expected": [
+          "Team                           | MP |  W |  D |  L |  P",
+          "Devastating Donkeys            |  3 |  2 |  1 |  0 |  7",
+          "Allegoric Alaskans             |  3 |  2 |  0 |  1 |  6",
+          "Blithering Badgers             |  3 |  1 |  0 |  2 |  3",
+          "Courageous Californians        |  3 |  0 |  1 |  2 |  1"
+        ]
+      },
+      {
+        "description": "incomplete competition (not all pairs have played)",
+        "input": [
+          "Allegoric Alaskans;Blithering Badgers;loss",
+          "Devastating Donkeys;Allegoric Alaskans;loss",
+          "Courageous Californians;Blithering Badgers;draw",
+          "Allegoric Alaskans;Courageous Californians;win"
+        ],
+        "expected": [
+          "Team                           | MP |  W |  D |  L |  P",
+          "Allegoric Alaskans             |  3 |  2 |  0 |  1 |  6",
+          "Blithering Badgers             |  2 |  1 |  1 |  0 |  4",
+          "Courageous Californians        |  2 |  0 |  1 |  1 |  1",
+          "Devastating Donkeys            |  1 |  0 |  0 |  1 |  0"
+        ]
+      },
+      {
+        "description": "ties broken alphabetically",
+        "input": [
+          "Courageous Californians;Devastating Donkeys;win",
+          "Allegoric Alaskans;Blithering Badgers;win",
+          "Devastating Donkeys;Allegoric Alaskans;loss",
+          "Courageous Californians;Blithering Badgers;win",
+          "Blithering Badgers;Devastating Donkeys;draw",
+          "Allegoric Alaskans;Courageous Californians;draw"
+        ],
+        "expected": [
+          "Team                           | MP |  W |  D |  L |  P",
+          "Allegoric Alaskans             |  3 |  2 |  1 |  0 |  7",
+          "Courageous Californians        |  3 |  2 |  1 |  0 |  7",
+          "Blithering Badgers             |  3 |  0 |  1 |  2 |  1",
+          "Devastating Donkeys            |  3 |  0 |  1 |  2 |  1"
+        ]
+      }
+    ]
+  },
+  "invalid_lines": {
+    "#": [
+      "Your track should test that, for each invalid line,",
+      "inserting the invalid line into an otherwise-valid game still results in valid output.",
+      "It's suggested to use one of the valid games above."
+    ],
+    "cases": [
+      {
+        "description": "an empty line",
+        "input": ""
+      },
+      {
+        "description": "wrong separator used",
+        "input": "Devastating Donkeys@Courageous Californians;draw"
+      },
+      {
+        "description": "too many separators",
+        "input": "Devastating Donkeys;Courageous Californians;draw;5"
+      },
+      {
+        "description": "invalid match result",
+        "input": "Devastating Donkeys;Allegoric Alaskans;dra"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
For the most part, the existing implementations all used the same tests:

* https://github.com/exercism/xcsharp/blob/master/exercises/tournament/TournamentTest.cs
* https://github.com/exercism/xfsharp/blob/master/exercises/tournament/TournamentTest.fs
* https://github.com/exercism/xgo/blob/master/exercises/tournament/tournament_test.go
* https://github.com/exercism/xrust/tree/master/exercises/tournament/tests
* https://github.com/exercism/xswift/blob/master/exercises/tournament/TournamentTest.swift

xgo is the clear outlier: Whereas all other tracks ignore invalid lines,
xgo declares that inputs with invalid lines cause an error (but empty
lines and comments are okay). Please refer to discussion in #286 where
we decide how to make this consistent across tracks.

For now, these tests follow the behavior of the other tracks.

xgo also had a test for ties which no other track had, so that's been
added. This tests that ties are broken alphabetically.

Discussion point: The README specifies that ties are broken first in
favor of the team with more wins. It's not possible to get a tie with a
different number of wins in a four-team group (one team must get one
win and no draws, while another team must get three draws and no wins).
We can test this by doing one of two things:
    
- A group with five teams
- A group where a pair plays each other more than once.
    
Should we test such a thing? Note that this is not usually seen in
football tournaments so such a test may be surprising to students.

Behaviors not tested:
* What happens on an empty input? Should the header be printed, with no
  rows in the result table?
* Should a team not be allowed to play itself? Should we test this? If
  so, it should be declared in the README that it's invalid for a team
  to play itself, of course.

Closes https://github.com/exercism/todo/issues/155