### PR TITLE
Add ocr-numbers test suite, update description

### DIFF
--- a/ocr-numbers.json
+++ b/ocr-numbers.json
@@ -1,0 +1,187 @@
+{
+  "#": [
+    "An expectation of  -1 indicates that a failure should be raised"
+  ],
+  "convert": {
+    "description": "Converts lines of OCR Numbers to a string of integers",
+    "cases": [
+      {
+        "description": "Recognizes 0",
+        "input": [
+          " _ ",
+          "| |",
+          "|_|",
+          "   "
+        ],
+        "expected": "0"
+      },
+      {
+        "description": "Recognizes 1",
+        "input": [
+          "   ",
+          "  |",
+          "  |",
+          "   "
+        ],
+        "expected": "1"
+      },
+      {
+        "description": "Unreadable but correctly sized inputs return ?",
+        "input": [
+          "   ",
+          "  _",
+          "  |",
+          "   "
+        ],
+        "expected": "?"
+      },
+      {
+        "description": "Input with a number of lines that is not a multiple of four raises an error",
+        "input": [
+          " _ ",
+          "| |",
+          "   "
+        ],
+        "expected": -1
+      },
+      {
+        "description": "Input with a number of columns that is not a multiple of three raises an error",
+        "input": [
+          "    ",
+          "   |",
+          "   |",
+          "    "
+        ],
+        "expected": -1
+      },
+      {
+        "description": "Recognizes 110101100",
+        "input": [
+          "       _     _        _  _ ",
+          "  |  || |  || |  |  || || |",
+          "  |  ||_|  ||_|  |  ||_||_|",
+          "                           "
+        ],
+        "expected": "110101100"
+      },
+      {
+        "description": "Garbled numbers in a string are replaced with ?",
+        "input": [
+          "       _     _           _ ",
+          "  |  || |  || |     || || |",
+          "  |  | _|  ||_|  |  ||_||_|",
+          "                           "
+        ],
+        "expected": "11?10?1?0"
+      },
+      {
+        "description": "Recognizes 2",
+        "input": [
+          " _ ",
+          " _|",
+          "|_ ",
+          "   "
+      ],
+      "expected": "2"
+      },
+      {
+      "description": "Recognizes 3",
+      "input": [
+        " _ ",
+        " _|",
+        " _|",
+        "   "
+      ],
+      "expected": "3"
+      },
+      {
+      "description": "Recognizes 4",
+      "input": [
+        "   ",
+        "|_|",
+        "  |",
+        "   "
+      ],
+      "expected": "4"
+      },
+      {
+      "description": "Recognizes 5",
+      "input": [
+        " _ ",
+        "|_ ",
+        " _|",
+        "   "
+      ],
+      "expected": "5"
+      },
+      {
+      "description": "Recognizes 6",
+      "input": [
+        " _ ",
+        "|_ ",
+        "|_|",
+        "   "
+      ],
+      "expected": "6"
+      },
+      {
+      "description": "Recognizes 7",
+      "input": [
+        " _ ",
+        "  |",
+        "  |",
+        "   "
+      ],
+      "expected": "7"
+      },
+      {
+      "description": "Recognizes 8",
+      "input": [
+        " _ ",
+        "|_|",
+        "|_|",
+        "   "
+      ],
+      "expected": "8"
+      },
+      {
+      "description": "Recognizes 9",
+      "input": [
+        " _ ",
+        "|_|",
+        " _|",
+        "   "
+      ],
+      "expected": "9"
+      },
+      {
+      "description": "Recognizes string of decimal numbers",
+      "input": [
+        "    _  _     _  _  _  _  _  _ ",
+        "  | _| _||_||_ |_   ||_||_|| |",
+        "  ||_  _|  | _||_|  ||_| _||_|",
+        "                              "
+      ],
+      "expected": "1234567890"
+      },
+      {
+      "description": "Numbers separated by empty lines are recognized. Empty lines are replaced with commas",
+      "input": [
+        "    _  _ ",
+        "  | _| _|",
+        "  ||_  _|",
+        "         ",
+        "    _  _ ",
+        "|_||_ |_ ",
+        "  | _||_|",
+        "         ",
+        " _  _  _ ",
+        "  ||_||_|",
+        "  ||_| _|",
+        "         "
+      ],
+      "expected": "123,456,789"
+      }
+    ]
+  }
+}

--- a/ocr-numbers.json
+++ b/ocr-numbers.json
@@ -165,7 +165,7 @@
       "expected": "1234567890"
       },
       {
-      "description": "Numbers separated by empty lines are recognized. Empty lines are replaced with commas",
+      "description": "Numbers separated by empty lines are recognized. Lines are joined by commas.",
       "input": [
         "    _  _ ",
         "  | _| _|",

--- a/ocr-numbers.md
+++ b/ocr-numbers.md
@@ -1,36 +1,74 @@
-## Step 1
+# Step One
 
-A simple binary font has been constructed using only pipes and
-underscores.
+To begin with, convert a simple binary font to a string containing 0 and 1.
 
-The number is four rows high, three columns wide:
+The binary font uses pipes and underscores, four rows high and three columns wide.
 
+```
      _   #
     | |  # zero.
     |_|  #
          # the fourth row is always blank
+```
 
+Is converted to "0"
+
+```
          #
       |  # one.
       |  #
          # (blank fourth row)
+```
 
-Write a program that, given a 3 x 4 grid of pipes, underscores, and
-spaces, can determine whether the the grid represents a zero, a one, or
-garble.
+Is converted to "1"
 
-Anything else is considered garble, and can be represented with a '?'
+If the input is the correct size, but not recognizable, your program should return '?'
 
-## Step 2
+If the input is the incorrect size, your program should return an error.
 
-A simple numeric font has been constructed using only pipes and
-underscores.
+# Step Two
 
-The number consists of four rows high, three columns wide:
+Update your program to recognize binary strings, replacing garbled numbers with ?
 
+# Step Three
+
+Update your program to recognize all numbers 0 through 9, both individually and as part of a larger string.
+
+```
+ _ 
+ _|
+|_ 
+   
+```
+
+Is converted to "2"
+
+```
       _  _     _  _  _  _  _  _  #
     | _| _||_||_ |_   ||_||_|| | # decimal numbers.
     ||_  _|  | _||_|  ||_| _||_| #
                                  # fourth line is always blank
+```
 
-There may be several numbers in the input text, one per line.
+Is converted to "1234567890"
+
+# Step Four
+
+Update your program to handle multiple numbers, one per line. When converting several lines, replace the empty lines with commas.
+
+```
+    _  _ 
+  | _| _|
+  ||_  _|
+         
+    _  _ 
+|_||_ |_ 
+  | _||_|
+         
+ _  _  _ 
+  ||_||_|
+  ||_| _|
+         
+```
+
+Is converted to "123,456,789"

--- a/ocr-numbers.md
+++ b/ocr-numbers.md
@@ -1,6 +1,6 @@
 # Step One
 
-To begin with, convert a simple binary font to a string containing 0 and 1.
+To begin with, convert a simple binary font to a string containing 0 or 1.
 
 The binary font uses pipes and underscores, four rows high and three columns wide.
 

--- a/ocr-numbers.md
+++ b/ocr-numbers.md
@@ -28,7 +28,7 @@ If the input is the incorrect size, your program should return an error.
 
 # Step Two
 
-Update your program to recognize binary strings, replacing garbled numbers with ?
+Update your program to recognize multi-character binary strings, replacing garbled numbers with ?
 
 # Step Three
 
@@ -54,7 +54,7 @@ Is converted to "1234567890"
 
 # Step Four
 
-Update your program to handle multiple numbers, one per line. When converting several lines, replace the empty lines with commas.
+Update your program to handle multiple numbers, one per line. When converting several lines, join the lines with commas.
 
 ```
     _  _ 


### PR DESCRIPTION
The tests come from the existing implementations. Most languages that
currently implement this problem use the exact same tests. The tests of
failures only exist in Python and Swift, but I thought they were useful
so I included them here.

While I've kept the existing tests, I have reordered them so that they
follow the problem as described in the readme. The problem progresses
from handling just single binary numbers, then garbling, then long binary
strings, then decimal numbers, then multi-line numbers.

I have also reworked the readme, clarifying the steps of the problem.