### PR TITLE
Raindrops: The factors are given, with no need to be prime.

### DIFF
--- a/raindrops.md
+++ b/raindrops.md
@@ -1,7 +1,7 @@
-- If the number contains 3 as a prime factor, output 'Pling'.
-- If the number contains 5 as a prime factor, output 'Plang'.
-- If the number contains 7 as a prime factor, output 'Plong'.
-- If the number does not contain 3, 5, or 7 as a prime factor,
+- If the number contains 3 as a factor, output 'Pling'.
+- If the number contains 5 as a factor, output 'Plang'.
+- If the number contains 7 as a factor, output 'Plong'.
+- If the number does not contain 3, 5, or 7 as a factor,
   just pass the number's digits straight through.
 
 ## Examples

--- a/raindrops.yml
+++ b/raindrops.yml
@@ -1,4 +1,4 @@
 ---
-blurb: "Write a program that converts a number to a string, the contents of which depends on the number's prime factors."
+blurb: "Write a program that converts a number to a string, the contents of which depends on the number's factors."
 source: "A variation on a famous interview question intended to weed out potential candidates."
 source_url: "http://jumpstartlab.com"


### PR DESCRIPTION
Giving a new rule where a non-prime number is expected to be a factor,
this should not fail.

fixes #294