### PR TITLE
Correct definition for the Triangle inequality

### DIFF
--- a/triangle.md
+++ b/triangle.md
@@ -2,6 +2,6 @@ The program should raise an error if the triangle cannot exist.
 
 ## Hint
 
-The sum of the lengths of any two sides of a triangle always exceeds the
-length of the third side, a principle known as the _triangle
+The sum of the lengths of any two sides of a triangle always exceeds or 
+is equal to the length of the third side, a principle known as the _triangle
 inequality_.


### PR DESCRIPTION
"or equal to" was missing.

In mathematics, the triangle inequality states that for any triangle,
the sum of the lengths of any two sides must be greater than or equal to
the length of the remaining side.

Source: https://en.wikipedia.org/wiki/Triangle_inequality