### PR TITLE
tournament: clarify behavior on invalid lines (ignore)

### DIFF
--- a/tournament.md
+++ b/tournament.md
@@ -61,4 +61,7 @@ Devastating Donkeys;Courageous Californians;draw
 
 Means that the Devastating Donkeys and Courageous Californians tied.
 
-Your program should only accept inputs that follow this format.
+Your program should only process input lines that follow this format.
+All other lines should be ignored:
+If an input contains both valid and invalid input lines,
+output a table that contains just the results from the valid lines.


### PR DESCRIPTION
"Only accept" was a bit vague - this commit changes the mesage to say
that invalid line are ignored, and the tournament scored without them.

This is in line with the behavior of all current tracks. If reviewers
wish a change to this behavior, we can discuss that in a separate PR.

(Note that the go track is an exception, but it clearly states it is an
exception in its test suite visible to students)

Closes #286
Closes https://github.com/exercism/xrust/issues/122