### PR TITLE
tournament: Remove tiebreak in favor of more wins

### DIFF
--- a/tournament.md
+++ b/tournament.md
@@ -20,7 +20,7 @@ What do those abbreviations mean?
 
 A win earns a team 3 points. A draw earns 1. A loss earns 0.
 
-The outcome should be ordered by points, descending. In case of a tie, the team with the most wins is ranked higher. If the teams have the same number of wins, then teams are ordered alphabetically.
+The outcome should be ordered by points, descending. In case of a tie, teams are ordered alphabetically.
 
 ###
 


### PR DESCRIPTION
Note that this sentence was added in #254 and previously was not
present. No track has a test case that tests this condition (equal
points, unequal number of wins).

Because of a combination of various factors:
* Teams play each other no more than once
* Four teams per group
* Wins award three points and draws one

It's not possible to have a tie with teams with unequal numbers of wins.
At the minimum:
* One team (A) would get one win and zero draws.
* One team (B) would get zero wins and three draws.

That's not possible, since at least one draw from team B would be
against team A, giving team A an extra point and breaking the tie.

We *can* solve this by breaking any one of the above three conditions.
If we would like to, we should make that explicit decision and edit the
JSON test cases to match. However, on the assumption that we want to
keep things as they are (and were before #254), this commit removes the
sentence.

This was the suggested course of action in #287.