### PR TITLE
binary: split error case tests

### DIFF
--- a/binary.json
+++ b/binary.json
@@ -46,14 +46,34 @@
          "expected": 31
       },
       {
-         "description": "numbers other than one and zero raise an error",
-         "binary": ["012", "2"],
-         "expected": -1
+        "description": "2 is not a valid binary digit",
+        "binary": "2",
+        "expected": null
       },
       {
-         "description": "containing letters raises an error",
-         "binary": ["10nope", "nope10", "10nope10", "001 nope"],
-         "expected": -1
+        "description": "a number containing a non-binary digit is invalid",
+        "binary": "01201",
+        "expected": null
+      },
+      {
+        "description": "a number with trailing non-binary characters is invalid",
+        "binary": "10nope",
+        "expected": null
+      },
+      {
+        "description": "a number with leading non-binary characters is invalid",
+        "binary": "nope10",
+        "expected": null
+      },
+      {
+        "description": "a number with internal non-binary characters is invalid",
+        "binary": "10nope10",
+        "expected": null
+      },
+      {
+        "description": "a number and a word whitespace spearated is invalid",
+        "binary": "001 nope",
+        "expected": null
       }
    ]
 }


### PR DESCRIPTION
Resolves #303

Does this seem like it covers all of the cases in the original? It felt to me like a number of the grouped assertions were testing the same thing, so I didn't include them all. I'm totally open to adding them, I just couldn't think of distinct names for all of them 😄!

Also, there has been some discussion about what the `expected` value should be. Both `null` and `-1` seem appropriate to me. I only chose to go with `-1` because I saw it used in the `hamming` data, so I assumed that was the standard. If this isn't the case, I'm happy to change it!

Thank you so much for your time and feedback! 😄 