### PR TITLE
connect: Add cases for 1x1 boards

### DIFF
--- a/connect.json
+++ b/connect.json
@@ -12,6 +12,20 @@
       "expected": ""
     },
     {
+      "description": "X can win on a 1x1 board",
+      "board": [
+        "X"
+      ],
+      "expected": "X"
+    },
+    {
+      "description": "O can win on a 1x1 board",
+      "board": [
+        "O"
+      ],
+      "expected": "O"
+    },
+    {
       "description": "only edges does not make a winner",
       "board": [
         "O O O X",


### PR DESCRIPTION
I think these are important since they're an interesting case for when a
start space in the search is also a goal space. I advocate for this in
original #297.