### PR TITLE
anagram: fix typo s/indentical/identical; rm duplicate cases; rm all "string argument" cases

### DIFF
--- a/anagram.json
+++ b/anagram.json
@@ -75,7 +75,7 @@
             "expected": ["carthorse"]
         },
         {
-            "description": "detects anagrams using case-insensitve possible matches",
+            "description": "detects anagrams using case-insensitive possible matches",
             "subject": "orchestra",
             "candidates": ["cashregister", "Carthorse", "radishes"],
             "expected": ["Carthorse"]

--- a/anagram.json
+++ b/anagram.json
@@ -51,7 +51,7 @@
             "expected": ["gallery", "regally", "largely"]
         },
         {
-            "description": "does not detect indentical words",
+            "description": "does not detect identical words",
             "subject": "corn",
             "candidates": ["corn", "dark", "Corn", "rank", "CORN", "cron", "park"],
             "expected": ["cron"]

--- a/anagram.json
+++ b/anagram.json
@@ -118,19 +118,5 @@
             "candidates": ["Banana"],
             "expected": []
         }
-    ],
-    "string argument cases": [
-        {
-            "description": "accepts string arguments",
-            "subject": "ant",
-            "candidates": ["stand", "tan", "at"],
-            "expected": ["tan"]
-        },
-        {
-            "description": "accepts single string argument",
-            "subject": "ant",
-            "candidates": ["tan"],
-            "expected": ["tan"]
-        }
     ]
 }

--- a/anagram.json
+++ b/anagram.json
@@ -99,12 +99,6 @@
             "expected": []
         },
         {
-            "description": "eliminates anagrams with the same checksum",
-            "subject": "mass",
-            "candidates": ["last"],
-            "expected": []
-        },
-        {
             "description": "detects unicode anagrams",
             "comment": "These words don't make sense, they're just greek letters cobbled together.",
             "subject": "ΑΒΓ",
@@ -122,13 +116,6 @@
             "description": "capital word is not own anagram",
             "subject": "BANANA",
             "candidates": ["Banana"],
-            "expected": []
-
-        },
-        {
-            "description": "anagrams must use all letters exactly once",
-            "subject": "patter",
-            "candidates": ["tapper"],
             "expected": []
         }
     ],


### PR DESCRIPTION
rationale in individual commit messages

Closes #248 (I know #248 said it should be for newbies but I didn't see #248 when I made this PR, and saw the duplication in https://github.com/exercism/xhaskell/pull/224 and resolved to do something about it)