### PR TITLE
triangle: Add JSON test data

### DIFF
--- a/triangle.json
+++ b/triangle.json
@@ -1,0 +1,90 @@
+{
+    "#": [
+        "Pursuant to discussion in #202,",
+        "we have decided NOT to test triangles where all side lengths are positive but a + b = c.",
+        "e.g: (2, 4, 2, Isosceles), (1, 3, 4, Scalene).",
+        "It's true that the triangle inequality admits such triangles.",
+        "These triangles have zero area, however.",
+        "They're degenerate triangles with all three vertices collinear.",
+        "(In contrast, we will test (0, 0, 0, Illegal), as it is a point).",
+
+        "The expectation are given as strings,",
+        "but your language may use the appropriate representations.",
+        "For example, enums, variants, or tagged unions all are viable candidates.",
+
+        "Your track may choose to have the 'illegal' result be another member of the enum/variant/union/etc.,",
+        "or instead to signal an error/exception/etc. on an illegal triangle.",
+
+        "If appropriate for your track, you'll need to ensure that no pair of expected values are equal.",
+        "Otherwise, an implementation that always returns a constant value may falsely pass the tests.",
+        "See https://github.com/exercism/xgo/pull/208"
+    ],
+    "cases": [
+        {
+            "description": "equilateral triangle has all sides equal",
+            "sides": [2, 2, 2],
+            "expected": "equilateral"
+        },
+        {
+            "description": "larger equilateral triangle",
+            "sides": [10, 10, 10],
+            "expected": "equilateral"
+        },
+        {
+            "description": "isosceles triangle with last two sides equal",
+            "sides": [3, 4, 4],
+            "expected": "isosceles"
+        },
+        {
+            "description": "isosceles triangle with first two sides equal",
+            "sides": [4, 4, 3],
+            "expected": "isosceles"
+        },
+        {
+            "description": "isosceles triangle with first and last sides equal",
+            "sides": [4, 3, 4],
+            "expected": "isosceles"
+        },
+        {
+            "description": "isosceles triangle with unequal side larger than equal sides",
+            "sides": [4, 7, 4],
+            "expected": "isosceles"
+        },
+        {
+            "description": "scalene triangle has no equal sides",
+            "sides": [3, 4, 5],
+            "expected": "scalene"
+        },
+        {
+            "description": "larger scalene triangle",
+            "sides": [10, 11, 12],
+            "expected": "scalene"
+        },
+        {
+            "description": "scalene triangle with sides in descending order",
+            "sides": [5, 4, 2],
+            "expected": "scalene"
+        },
+        {
+            "#": "Your track may choose to skip this test and deal only with integers if appropriate",
+            "description": "small scalene triangle with floating point values",
+            "sides": [0.4, 0.6, 0.3],
+            "expected": "scalene"
+        },
+        {
+            "description": "a triangle violating the triangle inequality is illegal",
+            "sides": [7, 3, 2],
+            "expected": "illegal"
+        },
+        {
+            "description": "two sides equal, but still violates triangle inequality",
+            "sides": [1, 1, 3],
+            "expected": "illegal"
+        },
+        {
+            "description": "triangles with all sides zero are illegal",
+            "sides": [0, 0, 0],
+            "expected": "illegal"
+        }
+    ]
+}


### PR DESCRIPTION
Pursuant to dicussion in #202, we won't have cases where a + b = c.
Examples are (2, 4, 2, Isosceles) and (1, 3, 4, Scalene).

As of this writing, 21 tracks implemented triangle:
* https://github.com/exercism/xcsharp/blob/master/exercises/triangle/TriangleTest.cs
* https://github.com/exercism/xcpp/blob/master/triangle/triangle_test.cpp
* https://github.com/exercism/xclojure/blob/master/exercises/triangle/test/triangle_test.clj
* https://github.com/exercism/xcoffeescript/blob/master/exercises/triangle/triangle_test.spec.coffee
* https://github.com/exercism/xlisp/blob/master/exercises/triangle/triangle-test.lisp
* https://github.com/exercism/xecmascript/blob/master/exercises/triangle/triangle.spec.js
* https://github.com/exercism/xelixir/blob/master/exercises/triangle/triangle_test.exs
* https://github.com/exercism/xelm/blob/master/exercises/triangle/TriangleTests.elm
* https://github.com/exercism/xerlang/blob/master/exercises/triangle/triangle_tests.erl
* https://github.com/exercism/xfsharp/blob/master/exercises/triangle/TriangleTest.fs
* https://github.com/exercism/xgo/blob/master/exercises/triangle/triangle_test.go
* https://github.com/exercism/xhaskell/blob/master/exercises/triangle/test/Tests.hs
* https://github.com/exercism/xjava/blob/master/exercises/triangle/src/test/java/TriangleTest.java
* https://github.com/exercism/xjavascript/blob/master/exercises/triangle/triangle.spec.js
* https://github.com/exercism/xlua/blob/master/exercises/triangle/triangle_spec.lua
* https://github.com/exercism/xnim/blob/master/triangle/triangle_test.nim
* https://github.com/exercism/xperl5/blob/master/triangle/cases.json
* https://github.com/exercism/xpython/blob/master/exercises/triangle/triangle_test.py
* https://github.com/exercism/xruby/blob/master/exercises/triangle/triangle_test.rb
* https://github.com/exercism/xscala/blob/master/exercises/triangle/src/test/scala/triangle_test.scala
* https://github.com/exercism/xswift/blob/master/exercises/triangle/TriangleTest.swift

This JSON file contains the combination of all their tests.
Most tracks have the same set of tests.

Haskell has a case specific to itself added in
exercism/xhaskell#142
This case is added to the common set.

The Go and Nim tracks have tests with +/- Infinity and NaN.
These cases are not added.

Closes #264
Closes exercism/todo#157