### PR TITLE
hello-world: Be more function-oriented, not program-oriented

### DIFF
--- a/hello-world.md
+++ b/hello-world.md
@@ -6,11 +6,12 @@
 
 ## Specification
 
-The `Hello World!` program will greet me, the caller.
+Write a `Hello World!` function that can greet someone given their name.
+The function should return the appropriate greeting.
 
-If I tell the program my name is Alice, it will greet me by saying "Hello, Alice!".
+For an input of "Alice", the response should be "Hello, Alice!".
 
-If I neglect to give it my name, it will greet me by saying "Hello, World!"
+If a name is not given, the response should be "Hello, World!"
 
 ## Test-Driven Development
 

--- a/hello-world.yml
+++ b/hello-world.yml
@@ -1,4 +1,4 @@
 ---
-blurb: 'Write a program that greets the user by name, or by saying "Hello, World!" if no name is given.'
-source: "This is a program to introduce users to using Exercism"
+blurb: 'Write a function that greets the user by name, or by saying "Hello, World!" if no name is given.'
+source: "This is an exercise to introduce users to using Exercism"
 source_url: "http://en.wikipedia.org/wiki/%22Hello,_world!%22_program"


### PR DESCRIPTION
As https://github.com/exercism/exercism.io/issues/2746 rightfully
explains, the wording of "program" implies that the student is expected
to write a full program with a main function (or equivalent entry point
in language of choice).

Further, the wording of "greets" slightly implies that the function is
expected to put the result on STDOUT.

To remedy this, "program" is replaced with "function" and we specify
that the function should return the greeting.

Note that as #321 states, this is just one of many problems that has
"write a program" in its description. However, the "greets" -> "returns"
wording is an issue not covered by #321, so we deal with it here.

Closes https://github.com/exercism/exercism.io/issues/2746