### PR TITLE
Fix minor mistake in sgf-parsing exercise

### DIFF
--- a/sgf-parsing.md
+++ b/sgf-parsing.md
@@ -37,7 +37,7 @@ supports variations of play sequences. For example:
 Here the root node has two variations. The first (which by convention
 indicates what's actually played) is where black plays on 1-1. Black was
 sent this file by his teacher who pointed out a more sensible play in
-the second child of the root node: `B[dd]` (3-3 point, a very standard
+the second child of the root node: `B[dd]` (4-4 point, a very standard
 opening to take the corner).
 
 A key can have multiple values associated with it. For example:

--- a/sgf-parsing.yml
+++ b/sgf-parsing.yml
@@ -1,2 +1,2 @@
 ---
-blurb: "Parsing a Standard Game Format string."
+blurb: "Parsing a Smart Game Format string."


### PR DESCRIPTION
In SGF, the node labeled `dd` is the 4-4 point, not the 3-3 point.

Also, SGF stands for [Smart Game Format](http://senseis.xmp.net/?SmartGameFormat), not Standard Game Format.

Neither of these will affect the actual exercise, but it's always worth getting the terms right in the README.