### PR TITLE
Remove Ruby examples from secret-handshake README.

### DIFF
--- a/secret-handshake.md
+++ b/secret-handshake.md
@@ -17,7 +17,7 @@ binary decide to come up with a secret "handshake".
 Here's a couple of examples:
 
 Given the input 9, the function would return the array
-["wink","jump"]
+["wink", "jump"]
 
 Given the input "11001", the function would return the array
 ["jump", "wink"]

--- a/secret-handshake.md
+++ b/secret-handshake.md
@@ -14,13 +14,14 @@ binary decide to come up with a secret "handshake".
 10000 = Reverse the order of the operations in the secret handshake.
 ```
 
-```
-handshake = SecretHandshake.new 9
-handshake.commands # => ["wink","jump"]
+Here's a couple of examples:
 
-handshake = SecretHandshake.new "11001"
-handshake.commands # => ["jump","wink"]
-```
+Given the input 9, the function would return the array
+["wink","jump"]
+
+Given the input "11001", the function would return the array
+["jump", "wink"]
+
 
 The program should consider strings specifying an invalid binary as the
 value 0.


### PR DESCRIPTION
Left both examples in as they were originally. It is worth noting
that the first example passes an integer and the second a string
to demonstrate that the exercise expects both types to be handled.

PR submitted in response to issue #171.