### PR TITLE
binary-search: add json test data

### DIFF
--- a/binary-search.json
+++ b/binary-search.json
@@ -1,0 +1,78 @@
+{
+    "#": [
+        "Here -1 is used to indicate that the value is not included in the array.",
+        "It should be replaced with the respective expression that is idiomatic",
+        "for the language that implements the tests.",
+
+        "Following https://github.com/exercism/x-common/issues/234 the exercise",
+        "should NOT include checking whether the array is sorted as it defeats",
+        "the point of the binary search.",
+
+        "The exercise should utilize an array-like (i.e. constant-time indexed)",
+        "data structure and not a linked list. If something like an array is not",
+        "usually used in the language the problem should not be implemented.",
+        "See https://github.com/exercism/x-common/issues/244 for details."
+    ],
+    "cases": [
+        {
+            "description": "finds a value in an array with one element",
+            "array": [6],
+            "value": 6,
+            "expected": 0
+        },
+        {
+            "description": "finds a value in the middle of an array",
+            "array": [1, 3, 4, 6, 8, 9, 11],
+            "value": 6,
+            "expected": 3
+        },
+        {
+            "description": "finds a value at the beginning of an array",
+            "array": [1, 3, 4, 6, 8, 9, 11],
+            "value": 1,
+            "expected": 0
+        },
+        {
+            "description": "finds a value at the end of an array",
+            "array": [1, 3, 4, 6, 8, 9, 11],
+            "value": 11,
+            "expected": 6
+        },
+        {
+            "description": "finds a value in an array of odd length",
+            "array": [1, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 634],
+            "value": 144,
+            "expected": 9
+        },
+        {
+            "description": "finds a value in an array of even length",
+            "array": [1, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377],
+            "value": 21,
+            "expected": 5
+        },
+        {
+            "description": "identifies that a value is not included in the array",
+            "array": [1, 3, 4, 6, 8, 9, 11],
+            "value": 7,
+            "expected": -1
+        },
+        {
+            "description": "a value smaller than the array's smallest value is not included",
+            "array": [1, 3, 4, 6, 8, 9, 11],
+            "value": 0,
+            "expected": -1
+        },
+        {
+            "description": "a value larger than the array's largest value is not included",
+            "array": [1, 3, 4, 6, 8, 9, 11],
+            "value": 13,
+            "expected": -1
+        },
+        {
+            "description": "nothing is included in an empty array",
+            "array": [],
+            "value": 1,
+            "expected": -1
+        }
+    ]
+}


### PR DESCRIPTION
Following the instructions proposed by @IanWhitney in #230, I created the missing json file with the test data for binary-search. Once this is merged https://github.com/exercism/todo/issues/73 can be closed.

There are two open issues regarding the exercise:
#234 - Following (and agreeing with) the majority there I did not include checking for sorted input. I also included a respective comment in the json file. The issue can be closed once the new test data is propagated through the tracks.
#244 - I included a comment with the summary of what was discussed there but the issue seems only partly addressed by this as there are additional ideas on how/where to address the issue.