### PR TITLE
update raindrops.md to not focus on prime factors

### DIFF
--- a/raindrops.md
+++ b/raindrops.md
@@ -6,10 +6,10 @@
 
 ## Examples
 
-- 28's prime-factorization is 2, 2, 7.
+- 28's factors are 2, 4, **7**, 14.
   - In raindrop-speak, this would be a simple "Plong".
-- 1755 prime-factorization is 3, 3, 3, 5, 13.
+- 30's factors are 2, **3**, **5**, 6, 15.
   - In raindrop-speak, this would be a "PlingPlang".
-- The prime factors of 34 are 2 and 17.
+- 34 only has two factors- 2 and 17.
   - Raindrop-speak doesn't know what to make of that,
     so it just goes with the straightforward "34".


### PR DESCRIPTION
The raindrops Readme is a little misleading by talking about prime factors. Raindrop-speak cares if a number is divisible by certain numbers. While those numbers do happen to be prime, their primeness shouldn't matter to solve this exercise. In the ruby track I've seen several folks require the `Prime` class to solve the exercise.

TBH, I would probably not use the word 'factor' at all & instead use 'divisible by'. Was 'divisible by' avoided to not give away the idea of using modulo too easily?