### PR TITLE
Remove unnecessary 'e.g.'

### DIFF
--- a/roman-numerals.yml
+++ b/roman-numerals.yml
@@ -1,4 +1,4 @@
 ---
-blurb: "Write a function to convert from normal numbers to Roman Numerals: e.g."
+blurb: "Write a function to convert from normal numbers to Roman Numerals:"
 source: "The Roman Numeral Kata"
 source_url: "http://codingdojo.org/cgi-bin/wiki.pl?KataRomanNumerals"

--- a/roman-numerals.yml
+++ b/roman-numerals.yml
@@ -1,4 +1,4 @@
 ---
-blurb: "Write a function to convert from normal numbers to Roman Numerals:"
+blurb: "Write a function to convert from normal numbers to Roman Numerals."
 source: "The Roman Numeral Kata"
 source_url: "http://codingdojo.org/cgi-bin/wiki.pl?KataRomanNumerals"


### PR DESCRIPTION
This is the current blurb: "Write a function to convert from normal numbers to Roman Numerals: e.g."
I think the "e.g." should be removed.
👍 
Otherwise it reads like this:

># Roman Numerals

>Write a function to convert from normal numbers to Roman Numerals: e.g.

>The Romans were a clever bunch. They conquered most of Europe and ruled
it for hundreds of years. They invented concrete and straight roads and
even bikinis. One thing they never discovered though was the number
zero. This made writing and dating extensive histories of their exploits
slightly more challenging, but the system of numbers they came up with
is still in use today. For example the BBC uses Roman numerals to date
their programmes.
