### PR TITLE
Fix incorrect example in all-your-base README

### DIFF
--- a/all-your-base.md
+++ b/all-your-base.md
@@ -18,9 +18,9 @@ The number 101010, *in base 2*, means:
 
 (1 * 2^5) + (0 * 2^4) + (1 * 2^3) + (0 * 2^2) + (1 * 2^1) + (0 * 2^0)
 
-The number 112, *in base 3*, means:
+The number 1120, *in base 3*, means:
 
-(1 * 3^2) + (1 * 3^1) + (2 * 3^0)
+(1 * 3^3) + (1 * 3^2) + (2 * 3^1) + (0 * 3^0)
 
 I think you got the idea!
 


### PR DESCRIPTION
The README of the new(ish) all-your-base exercise claims that the three example numbers are the same, but they aren't; the final zero was accidentally left off the trinary example. This PR fixes it, so that the claim on the README's final line will actually be true.

It also provides a perfect opportunity for mashing two memes together in the commit log. :sunglasses: