### PR TITLE
Standard test suite for pascals-triangle

### DIFF
--- a/exercises/pascals-triangle/canonical-data.json
+++ b/exercises/pascals-triangle/canonical-data.json
@@ -1,0 +1,47 @@
+{
+    "#": [
+      "Expectations are represented here as an array of arrays.",
+      "How you represent this idiomatically in your language is up to you.",
+      "An expectation of -1 indicates some sort of failure should occur"
+    ],
+    "rows": {
+      "description": "Given a count, return a collection of that many rows of pascal's triangle",
+      "cases": [
+        {
+            "description": "no rows",
+            "count": 0,
+            "expected": []
+        },
+        {
+            "description": "single row",
+            "count": 1,
+            "expected": [[1]]
+        },
+        {
+            "description": "two rows",
+            "count": 2,
+            "expected": [[1], [1, 1]]
+        },
+        {
+            "description": "three rows",
+            "count": 3,
+            "expected": [[1], [1, 1], [1, 2, 1]]
+        },
+        {
+            "description": "four rows",
+            "count": 4,
+            "expected": [[1], [1, 1], [1, 2, 1], [1, 3, 3, 1]]
+        },
+        {
+            "description": "negative rows",
+            "count": -1,
+            "expected": -1
+        },
+        {
+            "description": "no rows",
+            "count": null,
+            "expected": -1
+        }
+      ]
+    }
+}


### PR DESCRIPTION
In surveying the current implementations, I found 2 main approaches:

- Test 1, 2, 3, 4, 5 and 20 without any boundary checking
  - [Ruby](https://github.com/exercism/xruby/blob/e50b1cbeabc3a82c1ed7800da112b0984dbbf01c/exercises/pascals-triangle/pascals_triangle_test.rb) is a good example
- Test 4 & 6 rows, and test boundaries
  - [Kotlin](https://github.com/exercism/xkotlin/blob/02ecc5a70719f0b0e741992f33879f880f7c407f/exercises/pascals-triangle/src/test/kotlin/PascalsTriangleTest.kt)
    is a good example

Also, some languages exposed specific functions for `rows` and `last_row` while some relied on built-in functions for this behavior.

In this approach I'm trying to meld what I see as the best of these worlds.

`Rows` and `Last Row` functions
----

I think these functions should be implemented by the students, so I'm highlighting them as functions to test.

Fewer Tests
----

Once a student has gotten 4 rows to work the probably have the algorithm down. No real reason to test larger numbers that I can see.

Test Boundaries
----

An upper-limit test seemed unnecessary and very language-dependent. But catching Null and negative inputs seemed like useful things to test.