### PR TITLE
Test that "match entire lines" flag works properly

### DIFF
--- a/exercises/grep/canonical-data.json
+++ b/exercises/grep/canonical-data.json
@@ -67,6 +67,33 @@
                 ]
             },
             {
+                "description": "One file, one match, print file names flag",
+                "pattern": "Forbidden",
+                "flags": ["-l"],
+                "files": ["paradise-lost.txt"],
+                "expected": [
+                    "paradise-lost.txt"
+                ]
+            },
+            {
+                "description": "One file, one match, match entire lines flag",
+                "pattern": "With loss of Eden, till one greater Man",
+                "flags": ["-x"],
+                "files": ["paradise-lost.txt"],
+                "expected": [
+                    "With loss of Eden, till one greater Man"
+                ]
+            },
+            {
+                "description": "One file, one match, multiple flags",
+                "pattern": "OF ATREUS, Agamemnon, KIng of MEN.",
+                "flags": ["-n", "-i", "-x"],
+                "files": ["iliad.txt"],
+                "expected": [
+                    "9:Of Atreus, Agamemnon, King of men."
+                ]
+            },
+            {
                 "description": "One file, several matches, no flags",
                 "pattern": "may",
                 "flags": [],
@@ -96,15 +123,6 @@
                 "expected": []
             },
             {
-                "description": "One file, one match, print file names flag",
-                "pattern": "Forbidden",
-                "flags": ["-l"],
-                "files": ["paradise-lost.txt"],
-                "expected": [
-                    "paradise-lost.txt"
-                ]
-            },
-            {
                 "description": "One file, several matches, case-insensitive flag",
                 "pattern": "ACHILLES",
                 "flags": ["-i"],
@@ -125,24 +143,6 @@
                     "Restore us, and regain the blissful Seat,", 
                     "Sing Heav'nly Muse, that on the secret top",
                     "That Shepherd, who first taught the chosen Seed"
-                ]
-            },
-            {
-                "description": "One file, one match, match entire lines flag",
-                "pattern": "With loss of Eden, till one greater Man",
-                "flags": ["-x"],
-                "files": ["paradise-lost.txt"],
-                "expected": [
-                    "With loss of Eden, till one greater Man"
-                ]
-            },
-            {
-                "description": "One file, one match, multiple flags",
-                "pattern": "OF ATREUS, Agamemnon, KIng of MEN.",
-                "flags": ["-n", "-i", "-x"],
-                "files": ["iliad.txt"],
-                "expected": [
-                    "9:Of Atreus, Agamemnon, King of men."
                 ]
             },
             {

--- a/exercises/grep/canonical-data.json
+++ b/exercises/grep/canonical-data.json
@@ -67,6 +67,24 @@
                 ]
             },
             {
+                "description": "One file, one match, print line numbers flag",
+                "pattern": "Forbidden",
+                "flags": ["-n"],
+                "files": ["paradise-lost.txt"],
+                "expected": [
+                    "2:Of that Forbidden Tree, whose mortal tast"
+                ]
+            },
+            {
+                "description": "One file, one match, case-insensitive flag",
+                "pattern": "FORBIDDEN",
+                "flags": ["-i"],
+                "files": ["paradise-lost.txt"],
+                "expected": [
+                    "Of that Forbidden Tree, whose mortal tast"
+                ]
+            },
+            {
                 "description": "One file, one match, print file names flag",
                 "pattern": "Forbidden",
                 "flags": ["-l"],

--- a/exercises/grep/canonical-data.json
+++ b/exercises/grep/canonical-data.json
@@ -89,6 +89,13 @@
                 ]
             },
             {
+                "description": "One file, several matches, match entire lines flag",
+                "pattern": "may",
+                "flags": ["-x"],
+                "files": ["midsummer-night.txt"],
+                "expected": []
+            },
+            {
                 "description": "One file, one match, print file names flag",
                 "pattern": "Forbidden",
                 "flags": ["-l"],


### PR DESCRIPTION
Without this test, a solution to the "grep" exercise could get away with just ignoring the "-x" flag and having it not affect the code's behavior.

Fixes #368.