### PR TITLE
Validate json files in new location

### DIFF
--- a/bin/jsonlint
+++ b/bin/jsonlint
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 STATUS=0
-for f in $(ls *.json); do
+for f in $(ls exercises/**/*.json); do
 	cat $f | jq . > /dev/null 2>&1
 	if [ $? != 0 ]; then
 		echo "Invalid json: $f"


### PR DESCRIPTION
We restructured the exercise files to live under exercises/:slug/*. This updates
the json linting script to look for the json files in their new location.

Fixes #371