### PR TITLE
pov: Redraw to avoid confusion about edges between siblings

### DIFF
--- a/exercises/pov/description.md
+++ b/exercises/pov/description.md
@@ -5,11 +5,11 @@ point of view. For example family trees are usually presented from the
 ancestor's perspective:
 
 ```
-          0
-          |
-    1-----2-----3
-    |     |     |
-  4-+-5 6-+-7 8-+-9
+    +------0------+
+    |      |      |
+  +-1-+  +-2-+  +-3-+
+  |   |  |   |  |   |
+  4   5  6   7  8   9
 ```
 
 But the same information can be presented from the perspective of any other node
@@ -19,11 +19,13 @@ with it. So the same graph from 6's perspective would look like:
 ```
         6
         |
-  7-----+-----2
-              |
-        1-----0-----3
+  +-----2-----+
+  |           |
+  7     +-----0-----+
         |           |
-      4-+-5       8-+-9
+      +-1-+       +-3-+
+      |   |       |   |
+      4   5       8   9
 ```
 
 This lets us more simply describe the paths between two nodes. So for example


### PR DESCRIPTION
The following information is inferred from the supposition that in the
bottom graph the path from 6 to 9 is `6 2 0 3 9` as specified later in
the README:

In the top graph: 1, 2, 3 are all children of 0.
In the bottom graph: Only 0 is a child of 2, and 1 and 3 are children of
2.

However, the same ascii art was being used to describe both situations,
which makes it appear as if 1 and 3 are children of 2 in the original
graph. If that is the case, then one would believe that the path from 6
to 9 should be `6 2 3 9`. In addition, there would be no explanation for
how the rearranged graph got to be the way it is.

In general, this ascii art's branching strategy makes it appear as if
there is a path between two siblings, because they connect at a point
other than the parent node.

This commit redraws all the trees so that edges only go from parent to
child without connecting at any other point.

In the process, it also repairs an (apparent) mistake in the reparented
graph: 2 is the only child of 6; 7 should be a child of 2, not 6.

Closes exercism/xclojure#134
Closes #377