### PR TITLE
Remove redundancy from the description of isogram

### DIFF
--- a/exercises/isogram/description.md
+++ b/exercises/isogram/description.md
@@ -1,4 +1,3 @@
-Determine if a word or sentence is an isogram.
 An isogram (also known as a "nonpattern word") is a word or phrase without a repeating letter.
 
 Examples of isograms:


### PR DESCRIPTION
When the blurb from the metadata of isogram:

> Determine if a word or phrase is an isogram

is combined with the description text, the resulting exercise
description becomes redundant.

> Determine if a word or phrase is an isogram. Determine if a word or
> sentence is an isogram. An isogram ...

So, this commit removes the redundant part from `description.md`.