### PR TITLE
Amended hello-world/description.md to be formatted to 80 chars.

### DIFF
--- a/exercises/hello-world/description.md
+++ b/exercises/hello-world/description.md
@@ -1,4 +1,5 @@
-["Hello, World!"](http://en.wikipedia.org/wiki/%22Hello,_world!%22_program) is the traditional first program for beginning programming in a new language.
+["Hello, World!"](http://en.wikipedia.org/wiki/%22Hello,_world!%22_program) is
+the traditional first program for beginning programming in a new language.
 
 **Note:** You can skip this exercise by running:
 
@@ -6,8 +7,8 @@
 
 ## Specification
 
-Write a `Hello World!` function that can greet someone given their name.
-The function should return the appropriate greeting.
+Write a `Hello World!` function that can greet someone given their name.  The
+function should return the appropriate greeting.
 
 For an input of "Alice", the response should be "Hello, Alice!".
 
@@ -17,9 +18,14 @@ If a name is not given, the response should be "Hello, World!"
 
 As programmers mature, they eventually want to test their code.
 
-Here at Exercism we simulate [Test-Driven Development](http://en.wikipedia.org/wiki/Test-driven_development) (TDD), where you write your tests before writing any functionality. The simulation comes in the form of a pre-written test suite, which will signal that you have solved the problem.
+Here at Exercism we simulate [Test-Driven
+Development](http://en.wikipedia.org/wiki/Test-driven_development) (TDD), where
+you write your tests before writing any functionality. The simulation comes in
+the form of a pre-written test suite, which will signal that you have solved
+the problem.
 
-It will also provide you with a safety net to explore other solutions without breaking the functionality.
+It will also provide you with a safety net to explore other solutions without
+breaking the functionality.
 
 ### A typical TDD workflow on Exercism:
 
@@ -31,6 +37,10 @@ It will also provide you with a safety net to explore other solutions without br
 
 ## Instructions
 
-Submissions are encouraged to be general, within reason. Having said that, it's also important not to over-engineer a solution.
+Submissions are encouraged to be general, within reason. Having said that, it's
+also important not to over-engineer a solution.
 
-It's important to remember that the goal is to make code as expressive and readable as we can. However, solutions to the hello-world exercise will not be reviewed by a person, but by rikki- the robot, who will offer an encouraging word.
+It's important to remember that the goal is to make code as expressive and
+readable as we can. However, solutions to the hello-world exercise will not be
+reviewed by a person, but by rikki- the robot, who will offer an encouraging
+word.


### PR DESCRIPTION
Should allow reading of the rendered README.md easier if viewing in a restricted window.

I am not sure if this is even needed but I thought I would say anyway. I don't mind going through the rest of the ```description``` files and doing the same but I am aware this could be overkill.

When viewed through a restricted window in vim the README for a ```hello-world``` exercise was looking like this:

![screen shot 2016-09-25 at 00 38 58](https://cloud.githubusercontent.com/assets/356955/18811901/35494c02-82b9-11e6-9e20-f8b66cf5d35f.png)

A quick format and it now looks like this:

![screen shot 2016-09-25 at 00 44 57](https://cloud.githubusercontent.com/assets/356955/18811907/517f6dd4-82b9-11e6-969d-5bcdcbe2e4d6.png)

