### PR TITLE
Use nil instead of nill in description/blurb

### DIFF
--- a/exercises/flatten-array/description.md
+++ b/exercises/flatten-array/description.md
@@ -1,4 +1,4 @@
-The challenge is to write a function that accepts an arbitrarily-deep nested list-like structure and returns a flattened structure without any null/nill values. 
+The challenge is to write a function that accepts an arbitrarily-deep nested list-like structure and returns a flattened structure without any nil/null values.
  
 For Example
 

--- a/exercises/flatten-array/metadata.yml
+++ b/exercises/flatten-array/metadata.yml
@@ -1,4 +1,4 @@
 ---
-blurb: "Write a program that will take a nested list and returns a single list with all values except nill/null"
+blurb: "Write a program that will take a nested list and returns a single list with all values except nil/null"
 source: "Interview Question"
 source_url: "https://reference.wolfram.com/language/ref/Flatten.html"


### PR DESCRIPTION
This fixes a minor typo. Nill is the verb whereas nil is the noun.