### PR TITLE
say: adding canonical-data.json

### DIFF
--- a/exercises/say/canonical-data.json
+++ b/exercises/say/canonical-data.json
@@ -1,0 +1,83 @@
+{
+    "#": [
+        "Here -1 is used as expected value to indicate that the",
+        "input value is out of the range described in the exercise."
+    ],
+    "cases": [
+        {
+            "description": "zero",
+            "input": 0,
+            "expected": "zero"
+        },
+        {
+            "description": "one",
+            "input": 1,
+            "expected": "one"
+        },
+        {
+            "description": "fourteen",
+            "input": 14,
+            "expected": "fourteen"
+        },
+        {
+            "description": "twenty",
+            "input": 20,
+            "expected": "twenty"
+        },
+        {
+            "description": "twenty-two",
+            "input": 22,
+            "expected": "twenty-two"
+        },
+        {
+            "description": "one hundred",
+            "input": 100,
+            "expected": "one hundred"
+        },
+        {
+            "description": "one hundred twenty-three",
+            "input": 123,
+            "expected": "one hundred twenty-three"
+        },
+        {
+            "description": "one thousand",
+            "input": 1000,
+            "expected": "one thousand"
+        },
+        {
+            "description": "one thousand two hundred thirty-four",
+            "input": 1234,
+            "expected": "one thousand two hundred thirty-four"
+        },
+        {
+            "description": "one million",
+            "input": 1000000,
+            "expected": "one million"
+        },
+        {
+            "description": "one million two thousand three hundred forty-five",
+            "input": 1002345,
+            "expected": "one million two thousand three hundred forty-five"
+        },
+        {
+            "description": "one billion",
+            "input": 1000000000,
+            "expected": "one billion"
+        },
+        {
+            "description": "a big number",
+            "input": 987654321123,
+            "expected": "nine hundred eighty-seven billion six hundred fifty-four million three hundred twenty-one thousand one hundred twenty-three"
+        },
+        {
+            "description": "numbers below zero are out of range",
+            "input": -1,
+            "expected": -1
+        },
+        {
+            "description": "numbers above 999,999,999,999 are out of range",
+            "input": 1000000000000,
+            "expected": -1
+        }
+    ]
+}


### PR DESCRIPTION
This is to close https://github.com/exercism/todo/issues/142.
The test cases were quite homogeneous in the different tracks. I ignored the following outliers:
- A couple of tracks added one or two more numbers, in OCaml there a lot more numbers (especially all the "teeens" are tested), Ruby adds a couple more big numbers. I don't think the additions add much value for the exercise.
- The test for the upper bound is missing in Haskell and Go, Go instead let's people solve the exercise the max_int value. I prefer to have the upper bound in place (and covered by a test) as in the description of the exercise.

For discussion: The description in my PR and in the existing tests currently only contains the number that is tested instead of a real description. This is not "best practice" but changing to some declarative description would add little value and mean a lot of work for the individual tracks to adapt. Any thoughts on that?

Complete list of links to the implementations:
https://github.com/exercism/xcsharp/tree/master/exercises/say
https://github.com/exercism/xcpp/tree/master/say
https://github.com/exercism/xecmascript/tree/master/exercises/say
https://github.com/exercism/xelm/tree/master/exercises/say
https://github.com/exercism/xfsharp/tree/master/exercises/say
https://github.com/exercism/xgo/tree/master/exercises/say
https://github.com/exercism/xhaskell/tree/master/exercises/say
https://github.com/exercism/xjavascript/tree/master/exercises/say
https://github.com/exercism/xocaml/tree/master/exercises/say
https://github.com/exercism/xperl5/tree/master/say
https://github.com/exercism/xpython/tree/master/exercises/say
https://github.com/exercism/xracket/tree/master/exercises/say
https://github.com/exercism/xruby/tree/master/exercises/say
https://github.com/exercism/xscala/tree/master/exercises/say