### PR TITLE
Simplify alphametics. Fixes #395

### DIFF
--- a/exercises/alphametics/canonical-data.json
+++ b/exercises/alphametics/canonical-data.json
@@ -13,16 +13,6 @@
                 "expected": { "S": 9, "E": 5, "N": 6, "D": 7, "M": 1, "O": 0, "R": 8, "Y": 2 }
             },
             {
-                "description": "solve puzzle with multiplication",
-                "puzzle": "IF * DR == DORI",
-                "expected": { "I": 8, "F": 2, "D": 3, "R": 9, "O": 1 }
-            },
-            {
-                "description": "solve puzzle with exponents",
-                "puzzle": "PI * R ^ 2 == AREA",
-                "expected": { "P": 9, "I": 6, "R": 7, "A": 4, "E": 0 }
-            },
-            {
                 "description": "solution must have unique value for each letter",
                 "puzzle": "A == B",
                 "expected": null

--- a/exercises/alphametics/canonical-data.json
+++ b/exercises/alphametics/canonical-data.json
@@ -21,6 +21,16 @@
                 "description": "leading zero solution is invalid",
                 "puzzle": "ACA + DD == BD",
                 "expected": null
+            },
+            {
+                "description": "solve puzzle with four words",
+                "puzzle": "HE + SEES + THE == LIGHT",
+                "expected": { "E": 4, "G": 2, "H": 5, "I": 0, "L": 1, "S": 9, "T": 7 }
+            },
+            {
+                "description": "solve puzzle with many words",
+                "puzzle": "AND + A + STRONG + OFFENSE + AS + A + GOOD = DEFENSE",
+                "expected": { "A": 5, "D": 3, "E": 4, "F": 7, "G": 8, "N": 0, "O": 2, "R": 1, "S": 6, "T": 9 }
             }
         ]
     }


### PR DESCRIPTION
This change addresses the issues outlined in #395. Using only addition simplifies the exercise to focus on one thing. 