### PR TITLE
Add word count cases

### DIFF
--- a/exercises/word-count/canonical-data.json
+++ b/exercises/word-count/canonical-data.json
@@ -13,7 +13,7 @@
         {
             "description": "multiple occurrences of a word",
             "input": "one fish two fish red fish blue fish",
-            "expected": { "one" : 1, "fish" : 4, "two" : 1, "red" : 1, "blue" : 1 }
+            "expected": { "one": 1, "fish": 4, "two": 1, "red": 1, "blue": 1 }
         },
         {
             "description": "handles cramped lists",
@@ -27,18 +27,18 @@
         },
         {
             "description": "ignore punctuation",
-            "input": "car : carpet as java : javascript!!&@$%^&",
-            "expected": { "car" : 1, "carpet" : 1, "as" : 1, "java" : 1, "javascript" : 1 }
+            "input": "car: carpet as java: javascript!!&@$%^&",
+            "expected": { "car": 1, "carpet": 1, "as": 1, "java": 1, "javascript": 1 }
         },
         {
             "description": "include numbers",
             "input": "testing, 1, 2 testing",
-            "expected": { "testing" : 2, "1" : 1, "2" : 1 }
+            "expected": { "testing": 2, "1": 1, "2": 1 }
         },
         {
             "description": "normalize case",
             "input": "go Go GO Stop stop",
-            "expected": { "go" : 3, "stop" : 2 }
+            "expected": { "go": 3, "stop": 2 }
         },
         {
             "description": "with apostrophes",

--- a/exercises/word-count/canonical-data.json
+++ b/exercises/word-count/canonical-data.json
@@ -16,6 +16,16 @@
             "expected": { "one" : 1, "fish" : 4, "two" : 1, "red" : 1, "blue" : 1 }
         },
         {
+            "description": "handles cramped lists",
+            "input": "one,two,three",
+            "expected": { "one": 1, "two": 1, "three": 1 }
+        },
+        {
+            "description": "handles expanded lists",
+            "input": "one,\ntwo,\nthree",
+            "expected": { "one": 1, "two": 1, "three": 1 }
+        },
+        {
             "description": "ignore punctuation",
             "input": "car : carpet as java : javascript!!&@$%^&",
             "expected": { "car" : 1, "carpet" : 1, "as" : 1, "java" : 1, "javascript" : 1 }
@@ -29,6 +39,16 @@
             "description": "normalize case",
             "input": "go Go GO Stop stop",
             "expected": { "go" : 3, "stop" : 2 }
+        },
+        {
+            "description": "with apostrophes",
+            "input": "First: don't laugh. Then: don't cry.",
+            "expected": { "first": 1, "don't": 2, "laugh": 1, "then": 1, "cry": 1 }
+        },
+        {
+            "description": "with_quotations",
+            "input": "Joe can't tell between 'large' and large.",
+            "expected": { "joe": 1, "can't": 1, "tell": 1, "between": 1, "large": 2, "and": 1 }
         }
     ]
 }


### PR DESCRIPTION
Related to https://github.com/exercism/xruby/pull/448

Add four additional test cases:
- Handles cramped lists: Tests that words separated by commas and no spaces are counted.
- Handles expanded lists: Tests that words separated by commas and new lines are counted.
- With apostrophes: Checks that words with apostrophes are also counted as words.
- With quotations: Checks that words with quotations are also counted as words.