### PR TITLE
add GIMP acronym

### DIFF
--- a/exercises/acronym/canonical-data.json
+++ b/exercises/acronym/canonical-data.json
@@ -28,6 +28,11 @@
                 "expected": "PHP"
             },
             {
+                "description": "non-acronym all caps word",
+                "phrase": "GNU Image Manipulation Program",
+                "expected": "GIMP"
+            },
+            {
                 "description": "hyphenated",
                 "phrase": "Complementary metal-oxide semiconductor",
                 "expected": "CMOS"


### PR DESCRIPTION
From the  PHP example it isn't clear if the H and P come from "Hyptertext" and "Preprocessor" or from "HP" in the "PHP" at the front. GIMP makes it clear that it should just use the first letter of all caps words.