### PR TITLE
Amended description.md files to be formatted to 80 chars.

### DIFF
--- a/exercises/atbash-cipher/description.md
+++ b/exercises/atbash-cipher/description.md
@@ -15,10 +15,11 @@ a simple monoalphabetic substitution cipher. However, this may not have
 been an issue in the cipher's time.
 
 Ciphertext is written out in groups of fixed length, the traditional group size
-being 5 letters, and punctuation is excluded. This is to make it harder to guess
-things based on word boundaries.
+being 5 letters, and punctuation is excluded. This is to make it harder to
+guess things based on word boundaries.
 
 ## Examples
 - Encoding `test` gives `gvhg`
 - Decoding `gvhg` gives `test`
-- Decoding `gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt` gives `The quick brown fox jumps over the lazy dog.`
+- Decoding `gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt` gives `The quick brown
+  fox jumps over the lazy dog.`

--- a/exercises/bowling/description.md
+++ b/exercises/bowling/description.md
@@ -4,13 +4,22 @@ of a game of bowling.
 
 ## Scoring Bowling
 
-The game consists of 10 frames. A frame is composed of one or two ball throws with 10 pins standing at frame initialization. There are three cases for the tabulation of a frame.
+The game consists of 10 frames. A frame is composed of one or two ball throws
+with 10 pins standing at frame initialization. There are three cases for the
+tabulation of a frame.
 
-* An open frame is where a score of less than 10 is recorded for the frame. In this case the score for the frame is the number of pins knocked down.
+* An open frame is where a score of less than 10 is recorded for the frame. In
+  this case the score for the frame is the number of pins knocked down.
 
-* A spare is where all ten pins are knocked down after the second throw. The total value of a spare is 10 plus the number of pins knocked down in their next throw.
+* A spare is where all ten pins are knocked down after the second throw. The
+  total value of a spare is 10 plus the number of pins knocked down in their
+  next throw.
 
-* A strike is where all ten pins are knocked down after the first throw. The total value of a strike is 10 plus the number of pins knocked down in their next two throws. If a strike is immediately followed by a second strike, then we can not total the value of first strike until they throw the ball one more time.
+* A strike is where all ten pins are knocked down after the first throw. The
+  total value of a strike is 10 plus the number of pins knocked down in their
+  next two throws. If a strike is immediately followed by a second strike, then
+  we can not total the value of first strike until they throw the ball one more
+  time.
 
 Here is a three frame example:
 
@@ -26,7 +35,11 @@ Frame 3 is (9 + 0) = 9
 
 This means the current running total is 48.
 
-The tenth frame in the game is a special case. If someone throws a strike or a spare then they get a fill ball. Fill balls exist to calculate the total of the 10th frame. Scoring a strike or spare on the fill ball does not give the player more fill balls. The total value of the 10th frame is the total number of pins knocked down.
+The tenth frame in the game is a special case. If someone throws a strike or a
+spare then they get a fill ball. Fill balls exist to calculate the total of the
+10th frame. Scoring a strike or spare on the fill ball does not give the player
+more fill balls. The total value of the 10th frame is the total number of pins
+knocked down.
 
 For a tenth frame of X1/ (strike and a spare), the total value is 20.
 

--- a/exercises/crypto-square/description.md
+++ b/exercises/crypto-square/description.md
@@ -42,9 +42,10 @@ The message above is coded as:
 imtgdvsfearwermayoogoanouuiontnnlvtwttddesaohghnsseoau
 ```
 
-Output the encoded text in chunks.  Phrases that fill perfect squares
-`(r X r)` should be output in `r`-length chunks separated by spaces.
-Imperfect squares will have `n` empty spaces.  Those spaces should be distributed evenly across the last `n` rows.
+Output the encoded text in chunks.  Phrases that fill perfect squares `(r X r)`
+should be output in `r`-length chunks separated by spaces.  Imperfect squares
+will have `n` empty spaces.  Those spaces should be distributed evenly across
+the last `n` rows.
 
 ```plain
 imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn sseoau

--- a/exercises/dominoes/description.md
+++ b/exercises/dominoes/description.md
@@ -1,11 +1,15 @@
 Compute a way to order a given set of dominoes in such a way that they form a
 correct domino chain (the dots on one half of a stone match the dots on the
-neighbouring half of an adjacent stone) and that dots on the halfs of the stones
-which don't have a neighbour (the first and last stone) match each other.
+neighbouring half of an adjacent stone) and that dots on the halfs of the
+stones which don't have a neighbour (the first and last stone) match each
+other.
 
 For example given the stones `21`, `23` and `13` you should compute something
-like `12 23 31` or `32 21 13` or `13 32 21` etc, where the first and last numbers are the same.
+like `12 23 31` or `32 21 13` or `13 32 21` etc, where the first and last
+numbers are the same.
 
-For stones 12, 41 and 23 the resulting chain is not valid: 41 12 23's first and last numbers are not the same. 4 != 3
+For stones 12, 41 and 23 the resulting chain is not valid: 41 12 23's first and
+last numbers are not the same. 4 != 3
 
-Some test cases may use duplicate stones in a chain solution, assume that multiple Domino sets are being used.
+Some test cases may use duplicate stones in a chain solution, assume that
+multiple Domino sets are being used.

--- a/exercises/etl/description.md
+++ b/exercises/etl/description.md
@@ -1,6 +1,7 @@
 ### ETL
-Extract-Transform-Load (ETL) is a fancy way of saying, "We have some crufty, legacy data over in this system, and now we need it in this shiny new system over here, so
-we're going to migrate this."
+Extract-Transform-Load (ETL) is a fancy way of saying, "We have some crufty,
+legacy data over in this system, and now we need it in this shiny new system
+over here, so we're going to migrate this."
 
 (Typically, this is followed by, "We're only going to need to run this
 once." That's then typically followed by much forehead slapping and

--- a/exercises/flatten-array/description.md
+++ b/exercises/flatten-array/description.md
@@ -1,4 +1,6 @@
-The challenge is to write a function that accepts an arbitrarily-deep nested list-like structure and returns a flattened structure without any nil/null values.
+The challenge is to write a function that accepts an arbitrarily-deep nested
+list-like structure and returns a flattened structure without any nil/null
+values.
  
 For Example
 

--- a/exercises/food-chain/description.md
+++ b/exercises/food-chain/description.md
@@ -4,7 +4,8 @@ copy/paste the lyrics, or read them from a file, this
 problem is much more interesting if you approach it
 algorithmically.
 
-This is a [cumulative song](http://en.wikipedia.org/wiki/Cumulative_song) of unknown origin.
+This is a [cumulative song](http://en.wikipedia.org/wiki/Cumulative_song) of
+unknown origin.
 
 This is one of many common variants.
 
@@ -19,14 +20,16 @@ I don't know why she swallowed the fly. Perhaps she'll die.
 
 I know an old lady who swallowed a bird.
 How absurd to swallow a bird!
-She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.
+She swallowed the bird to catch the spider that wriggled and jiggled and
+tickled inside her.
 She swallowed the spider to catch the fly.
 I don't know why she swallowed the fly. Perhaps she'll die.
 
 I know an old lady who swallowed a cat.
 Imagine that, to swallow a cat!
 She swallowed the cat to catch the bird.
-She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.
+She swallowed the bird to catch the spider that wriggled and jiggled and
+tickled inside her.
 She swallowed the spider to catch the fly.
 I don't know why she swallowed the fly. Perhaps she'll die.
 
@@ -34,7 +37,8 @@ I know an old lady who swallowed a dog.
 What a hog, to swallow a dog!
 She swallowed the dog to catch the cat.
 She swallowed the cat to catch the bird.
-She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.
+She swallowed the bird to catch the spider that wriggled and jiggled and
+tickled inside her.
 She swallowed the spider to catch the fly.
 I don't know why she swallowed the fly. Perhaps she'll die.
 
@@ -43,7 +47,8 @@ Just opened her throat and swallowed a goat!
 She swallowed the goat to catch the dog.
 She swallowed the dog to catch the cat.
 She swallowed the cat to catch the bird.
-She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.
+She swallowed the bird to catch the spider that wriggled and jiggled and
+tickled inside her.
 She swallowed the spider to catch the fly.
 I don't know why she swallowed the fly. Perhaps she'll die.
 
@@ -53,7 +58,8 @@ She swallowed the cow to catch the goat.
 She swallowed the goat to catch the dog.
 She swallowed the dog to catch the cat.
 She swallowed the cat to catch the bird.
-She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.
+She swallowed the bird to catch the spider that wriggled and jiggled and
+tickled inside her.
 She swallowed the spider to catch the fly.
 I don't know why she swallowed the fly. Perhaps she'll die.
 

--- a/exercises/grep/description.md
+++ b/exercises/grep/description.md
@@ -1,5 +1,6 @@
-The Unix [`grep`](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/grep.html) command can be used to search for lines in one or more files 
-that match a user-provided search query (known as the *pattern*).
+The Unix [`grep`](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/grep.html) 
+command can be used to search for lines in one or more files that match a
+user-provided search query (known as the *pattern*).
 
 The `grep` command takes three arguments:
 
@@ -13,7 +14,8 @@ and then output those lines as a single string. Note that the lines should
 be output in the order in which they were found, with the first matching line
 in the first file being output first.
 
-As an example, suppose there is a file named "input.txt" with the following contents:
+As an example, suppose there is a file named "input.txt" with the following
+contents:
 
 <pre>
 hello

--- a/exercises/isogram/description.md
+++ b/exercises/isogram/description.md
@@ -1,4 +1,5 @@
-An isogram (also known as a "nonpattern word") is a word or phrase without a repeating letter.
+An isogram (also known as a "nonpattern word") is a word or phrase without a
+repeating letter.
 
 Examples of isograms:
 

--- a/exercises/ocr-numbers/description.md
+++ b/exercises/ocr-numbers/description.md
@@ -2,7 +2,8 @@
 
 To begin with, convert a simple binary font to a string containing 0 or 1.
 
-The binary font uses pipes and underscores, four rows high and three columns wide.
+The binary font uses pipes and underscores, four rows high and three columns
+wide.
 
 ```
      _   #
@@ -22,17 +23,20 @@ Is converted to "0"
 
 Is converted to "1"
 
-If the input is the correct size, but not recognizable, your program should return '?'
+If the input is the correct size, but not recognizable, your program should
+return '?'
 
 If the input is the incorrect size, your program should return an error.
 
 # Step Two
 
-Update your program to recognize multi-character binary strings, replacing garbled numbers with ?
+Update your program to recognize multi-character binary strings, replacing
+garbled numbers with ?
 
 # Step Three
 
-Update your program to recognize all numbers 0 through 9, both individually and as part of a larger string.
+Update your program to recognize all numbers 0 through 9, both individually and
+as part of a larger string.
 
 ```
  _ 
@@ -54,7 +58,8 @@ Is converted to "1234567890"
 
 # Step Four
 
-Update your program to handle multiple numbers, one per line. When converting several lines, join the lines with commas.
+Update your program to handle multiple numbers, one per line. When converting
+several lines, join the lines with commas.
 
 ```
     _  _ 

--- a/exercises/pangram/description.md
+++ b/exercises/pangram/description.md
@@ -1,6 +1,7 @@
 Determine if a sentence is a pangram. A pangram (Greek: παν γράμμα, pan gramma,
 "every letter") is a sentence using every letter of the alphabet at least once.
-The best known English pangram is "The quick brown fox jumps over the lazy dog."
+The best known English pangram is "The quick brown fox jumps over the lazy
+dog."
 
 The alphabet used is ASCII, and case insensitive, from 'a' to 'z'
 inclusively.

--- a/exercises/pov/description.md
+++ b/exercises/pov/description.md
@@ -1,8 +1,8 @@
 # Tree Reparenting
 
-This exercise is all about re-orientating a graph to see things from a different
-point of view. For example family trees are usually presented from the
-ancestor's perspective:
+This exercise is all about re-orientating a graph to see things from a
+different point of view. For example family trees are usually presented from
+the ancestor's perspective:
 
 ```
     +------0------+
@@ -12,9 +12,9 @@ ancestor's perspective:
   4   5  6   7  8   9
 ```
 
-But the same information can be presented from the perspective of any other node
-in the graph, by pulling it up to the root and dragging its relationships along
-with it. So the same graph from 6's perspective would look like:
+But the same information can be presented from the perspective of any other
+node in the graph, by pulling it up to the root and dragging its relationships
+along with it. So the same graph from 6's perspective would look like:
 
 ```
         6
@@ -29,8 +29,8 @@ with it. So the same graph from 6's perspective would look like:
 ```
 
 This lets us more simply describe the paths between two nodes. So for example
-the path from 6-9 (which in the first graph goes up to the root and then down to
-a different leaf node) can be seen to follow the path 6-2-0-3-9
+the path from 6-9 (which in the first graph goes up to the root and then down
+to a different leaf node) can be seen to follow the path 6-2-0-3-9
 
-This exercise involves taking an input graph and re-orientating it from the point
-of view of one of the nodes.
+This exercise involves taking an input graph and re-orientating it from the
+point of view of one of the nodes.

--- a/exercises/protein-translation/description.md
+++ b/exercises/protein-translation/description.md
@@ -1,6 +1,8 @@
-Lets write a program that will translate RNA sequences into proteins. [general ref](http://en.wikipedia.org/wiki/Translation_(biology)
-
-RNA can be broken into three nucleotide sequences called codons, and then translated to a polypeptide like so:
+Lets write a program that will translate RNA sequences into proteins. 
+[general ref](http://en.wikipedia.org/wiki/Translation_(biology))
+ 
+RNA can be broken into three nucleotide sequences called codons, and then
+translated to a polypeptide like so:
 
 RNA: `"AUGUUUUCU"` => translates to
 
@@ -9,10 +11,14 @@ Codons: `"AUG", "UUU", "UCU"`
 
 Protein: `"Methionine", "Phenylalanine", "Serine"`
  
-There are 64 codons which in turn correspond to 20 amino acids; however, all of the codon sequences and resulting amino acids are not important in this exercise.  If it works for one codon, the program should work for all of them.
+There are 64 codons which in turn correspond to 20 amino acids; however, all of
+the codon sequences and resulting amino acids are not important in this
+exercise.  If it works for one codon, the program should work for all of them.
 However, feel free to expand the list in the test suite to include them all.  
 
-There are also four terminating codons (also known as 'STOP' codons); if any of these codons are encountered (by the ribosome), all translation ends and the protein is terminated.
+There are also four terminating codons (also known as 'STOP' codons); if any of
+these codons are encountered (by the ribosome), all translation ends and the
+protein is terminated.
 
 All subsequent codons after are ignored, like this:
 
@@ -22,7 +28,8 @@ Codons: `"AUG", "UUU", "UCU", "UAG", "AUG"` =>
 
 Protein: `"Methionine", "Phenylalanine", "Serine"`
 
-Note the stop codon terminates the translation and the final methionine is not translated into the protein sequence.
+Note the stop codon terminates the translation and the final methionine is not
+translated into the protein sequence.
 
 Below are the codons and resulting Amino Acids needed for the exercise.
 

--- a/exercises/rail-fence-cipher/description.md
+++ b/exercises/rail-fence-cipher/description.md
@@ -1,12 +1,12 @@
 The Rail Fence cipher is a form of transposition cipher that gets its name from
 the way in which it's encoded. It was already used by the ancient Greeks.
 
-In the Rail Fence cipher, the message is written downwards on successive "rails"
-of an imaginary fence, then moving up when we get to the bottom (like a zig-zag).
-Finally the message is then read off in rows.
+In the Rail Fence cipher, the message is written downwards on successive
+"rails" of an imaginary fence, then moving up when we get to the bottom (like a
+zig-zag).  Finally the message is then read off in rows.
 
-For example, using three "rails" and the message "WE ARE DISCOVERED FLEE AT ONCE",
-the cipherer writes out:
+For example, using three "rails" and the message "WE ARE DISCOVERED FLEE AT
+ONCE", the cipherer writes out:
 ```
 W . . . E . . . C . . . R . . . L . . . T . . . E
 . E . R . D . S . O . E . E . F . E . A . O . C .
@@ -19,7 +19,8 @@ WECRLTEERDSOEEFEAOCAIVDEN
 ```
 
 
-To decrypt a message you take the zig-zag shape and fill the ciphertext along the rows.
+To decrypt a message you take the zig-zag shape and fill the ciphertext along
+the rows.
 ```
 ? . . . ? . . . ? . . . ? . . . ? . . . ? . . . ?
 . ? . ? . ? . ? . ? . ? . ? . ? . ? . ? . ? . ? .

--- a/exercises/scale-generator/description.md
+++ b/exercises/scale-generator/description.md
@@ -43,11 +43,13 @@ a "whole step" or "major second" (written as an upper-case "M"). The
 diatonic scales are built using only these two intervals between
 adjacent notes.
 
-Non-diatonic scales can contain the same letter twice, and can contain other intervals.
-Sometimes they may be smaller than usual (diminished, written "D"), or larger
-(augmented, written "A").  Intervals larger than an augmented second have other names.
+Non-diatonic scales can contain the same letter twice, and can contain other
+intervals.  Sometimes they may be smaller than usual (diminished, written "D"),
+or larger (augmented, written "A").  Intervals larger than an augmented second
+have other names.
 
-Here is a table of pitches with the names of their interval distance from the tonic (A).
+Here is a table of pitches with the names of their interval distance from the
+tonic (A).
 
     A    |    A#   |    B    |    C    |    C#   |    D    |    D#   |
 ----------------------------------------------------------------------

--- a/exercises/sieve/description.md
+++ b/exercises/sieve/description.md
@@ -3,7 +3,8 @@ prime numbers up to any given limit. It does so by iteratively marking as
 composite (i.e. not prime) the multiples of each prime,
 starting with the multiples of 2.
 
-Create your range, starting at two and continuing up to and including the given limit. (i.e. [2, limit])
+Create your range, starting at two and continuing up to and including the given
+limit. (i.e. [2, limit])
 
 The algorithm consists of repeating the following over and over:
 

--- a/exercises/simple-cipher/description.md
+++ b/exercises/simple-cipher/description.md
@@ -23,7 +23,8 @@ This image is a great example of the Caesar Cipher: ![Caesar Cipher][1]
 
 For example:
 
-Giving "iamapandabear" as input to the encode function returns the cipher "ldpdsdqgdehdu". Obscure enough to keep our message secret in transit.
+Giving "iamapandabear" as input to the encode function returns the cipher
+"ldpdsdqgdehdu". Obscure enough to keep our message secret in transit.
 
 When "ldpdsdqgdehdu" is put into the decode function it would return
 the original "iamapandabear" letting your friend read your original

--- a/exercises/sublist/description.md
+++ b/exercises/sublist/description.md
@@ -14,4 +14,5 @@ Examples:
  * A = [3, 4], B = [1, 2, 3, 4, 5], A is a sublist of B
  * A = [1, 2, 3], B = [1, 2, 3], A is equal to B
  * A = [1, 2, 3, 4, 5], B = [2, 3, 4], A is a superlist of B
- * A = [1, 2, 4], B = [1, 2, 3, 4, 5], A is not a superlist of, sublist of or equal to B
+ * A = [1, 2, 4], B = [1, 2, 3, 4, 5], A is not a superlist of, sublist of or
+   equal to B

--- a/exercises/tournament/description.md
+++ b/exercises/tournament/description.md
@@ -20,7 +20,8 @@ What do those abbreviations mean?
 
 A win earns a team 3 points. A draw earns 1. A loss earns 0.
 
-The outcome should be ordered by points, descending. In case of a tie, teams are ordered alphabetically.
+The outcome should be ordered by points, descending. In case of a tie, teams
+are ordered alphabetically.
 
 ###
 

--- a/exercises/transpose/description.md
+++ b/exercises/transpose/description.md
@@ -52,6 +52,7 @@ BE
  F
 ```
 
-In general, all characters from the input should also be present in the transposed output.
-That means that if a column in the input text contains only spaces on its bottom-most row(s), 
-the corresponding output row should contain the spaces in its right-most column(s).
+In general, all characters from the input should also be present in the
+transposed output.  That means that if a column in the input text contains only
+spaces on its bottom-most row(s), the corresponding output row should contain
+the spaces in its right-most column(s).

--- a/exercises/twelve-days/description.md
+++ b/exercises/twelve-days/description.md
@@ -1,25 +1,49 @@
 ```ruby
-On the first day of Christmas my true love gave to me, a Partridge in a Pear Tree.
+On the first day of Christmas my true love gave to me, a Partridge in a Pear
+Tree.
+ 
+On the second day of Christmas my true love gave to me, two Turtle Doves, and a
+Partridge in a Pear Tree.
 
-On the second day of Christmas my true love gave to me, two Turtle Doves, and a Partridge in a Pear Tree.
+On the third day of Christmas my true love gave to me, three French Hens, two
+Turtle Doves, and a Partridge in a Pear Tree.
 
-On the third day of Christmas my true love gave to me, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+On the fourth day of Christmas my true love gave to me, four Calling Birds,
+three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
 
-On the fourth day of Christmas my true love gave to me, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+On the fifth day of Christmas my true love gave to me, five Gold Rings, four
+Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear
+Tree.
 
-On the fifth day of Christmas my true love gave to me, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+On the sixth day of Christmas my true love gave to me, six Geese-a-Laying, five
+Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a
+Partridge in a Pear Tree.
 
-On the sixth day of Christmas my true love gave to me, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+On the seventh day of Christmas my true love gave to me, seven
+Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds,
+three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
 
-On the seventh day of Christmas my true love gave to me, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+On the eighth day of Christmas my true love gave to me, eight Maids-a-Milking,
+seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling
+Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
 
-On the eighth day of Christmas my true love gave to me, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+On the ninth day of Christmas my true love gave to me, nine Ladies Dancing,
+eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold
+Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge
+in a Pear Tree.
 
-On the ninth day of Christmas my true love gave to me, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+On the tenth day of Christmas my true love gave to me, ten Lords-a-Leaping,
+nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six
+Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two
+Turtle Doves, and a Partridge in a Pear Tree.
 
-On the tenth day of Christmas my true love gave to me, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+On the eleventh day of Christmas my true love gave to me, eleven Pipers Piping,
+ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven
+Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds,
+three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
 
-On the eleventh day of Christmas my true love gave to me, eleven Pipers Piping, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
-
-On the twelfth day of Christmas my true love gave to me, twelve Drummers Drumming, eleven Pipers Piping, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
-```
+On the twelfth day of Christmas my true love gave to me, twelve Drummers
+Drumming, eleven Pipers Piping, ten Lords-a-Leaping, nine Ladies Dancing, eight
+Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings,
+four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a
+Pear Tree.  ```

--- a/exercises/two-bucket/description.md
+++ b/exercises/two-bucket/description.md
@@ -1,8 +1,15 @@
-Given two buckets of different size, write a program to demonstrate how to measure an exact number of liters by strategically transferring liters of fluid between the buckets.
+Given two buckets of different size, write a program to demonstrate how to
+measure an exact number of liters by strategically transferring liters of fluid
+between the buckets.
 
-Since this mathematical problem is fairly subject to interpretation / individual approach, the tests have been written specifically to expect one overarching solution.
+Since this mathematical problem is fairly subject to interpretation /
+individual approach, the tests have been written specifically to expect one
+overarching solution.
 
-To help, the tests provide you with which bucket to fill first. That means, when starting with the larger bucket full, you are NOT allowed at any point to have the smaller bucket full and the larger bucket empty (aka, the opposite starting point); that would defeat the purpose of comparing both approaches! 
+To help, the tests provide you with which bucket to fill first. That means,
+when starting with the larger bucket full, you are NOT allowed at any point to
+have the smaller bucket full and the larger bucket empty (aka, the opposite
+starting point); that would defeat the purpose of comparing both approaches! 
 
 Your program will take as input:
 - the size of bucket one, passed as a numeric value
@@ -11,18 +18,29 @@ Your program will take as input:
 - which bucket to fill first, passed as a String (either 'one' or 'two')
 
 Your program should determine:
-- the total number of "moves" it should take to reach the desired number of liters, including the first fill - expects a numeric value
-- which bucket should end up with the desired number of liters (let's say this is bucket A) - expects a String (either 'one' or 'two')
-- how many liters are left in the other bucket (bucket B) - expects a numeric value
+- the total number of "moves" it should take to reach the desired number of
+  liters, including the first fill - expects a numeric value
+- which bucket should end up with the desired number of liters (let's say this
+  is bucket A) - expects a String (either 'one' or 'two')
+- how many liters are left in the other bucket (bucket B) - expects a numeric
+  value
 
-Note: any time a change is made to either or both buckets counts as one (1) move. 
+Note: any time a change is made to either or both buckets counts as one (1)
+move. 
 
 Example: 
-Bucket one can hold up to 7 liters, and bucket two can hold up to 11 liters. Let's say bucket one, at a given step, is holding 7 liters, and bucket two is holding 8 liters (7,8). If you empty bucket one and make no change to bucket two, leaving you with 0 liters and 8 liters respectively (0,8), that counts as one "move". Instead, if you had poured from bucket one into bucket two until bucket two was full, leaving you with 4 liters in bucket one and 11 liters in bucket two (4,11), that would count as only one "move" as well.
+Bucket one can hold up to 7 liters, and bucket two can hold up to 11 liters.
+Let's say bucket one, at a given step, is holding 7 liters, and bucket two is
+holding 8 liters (7,8). If you empty bucket one and make no change to bucket
+two, leaving you with 0 liters and 8 liters respectively (0,8), that counts as
+one "move". Instead, if you had poured from bucket one into bucket two until
+bucket two was full, leaving you with 4 liters in bucket one and 11 liters in
+bucket two (4,11), that would count as only one "move" as well.
 
 To conclude, the only valid moves are:
 - pouring from one bucket to another
 - emptying one bucket and doing nothing to the other
 - filling one bucket and doing nothing to the other
 
-Written with <3 at [Fullstack Academy](http://www.fullstackacademy.com/) by [Lindsay](http://lindsaylevine.com).
+Written with <3 at [Fullstack Academy](http://www.fullstackacademy.com/) by
+[Lindsay](http://lindsaylevine.com).

--- a/exercises/variable-length-quantity/description.md
+++ b/exercises/variable-length-quantity/description.md
@@ -1,15 +1,17 @@
 The goal of this exercise is to implement [VLQ](https://en.wikipedia.org/wiki/Variable-length_quantity) encoding/decoding.
 
-In short, the goal of this encoding is to encode integer values in a way that would save bytes.
-Only the first 7 bits of each byte is significant (right-justified; sort of like an ASCII byte). 
-So, if you have a 32-bit value, you have to unpack it into a series of 7-bit bytes. 
-Of course, you will have a variable number of bytes depending upon your integer. 
-To indicate which is the last byte of the series, you leave bit #7 clear.
-In all of the preceding bytes, you set bit #7. 
+In short, the goal of this encoding is to encode integer values in a way that
+would save bytes.  Only the first 7 bits of each byte is significant
+(right-justified; sort of like an ASCII byte).  So, if you have a 32-bit value,
+you have to unpack it into a series of 7-bit bytes.  Of course, you will have a
+variable number of bytes depending upon your integer.  To indicate which is the
+last byte of the series, you leave bit #7 clear.  In all of the preceding
+bytes, you set bit #7. 
 
-So, if an integer is between `0-127`, it can be represented as one byte. 
-The largest integer allowed is `0FFFFFFF`, which translates to 4 bytes variable length. 
-Here are examples of delta-times as 32-bit values, and the variable length quantities that they translate to:
+So, if an integer is between `0-127`, it can be represented as one byte.  The
+largest integer allowed is `0FFFFFFF`, which translates to 4 bytes variable
+length.  Here are examples of delta-times as 32-bit values, and the variable
+length quantities that they translate to:
 
 
 ```

--- a/exercises/zebra-puzzle/description.md
+++ b/exercises/zebra-puzzle/description.md
@@ -8,7 +8,8 @@
 8. Kools are smoked in the yellow house.
 9. Milk is drunk in the middle house.
 10. The Norwegian lives in the first house.
-11. The man who smokes Chesterfields lives in the house next to the man with the fox.
+11. The man who smokes Chesterfields lives in the house next to the man with
+    the fox.
 12. Kools are smoked in the house next to the house where the horse is kept.
 13. The Lucky Strike smoker drinks orange juice.
 14. The Japanese smokes Parliaments.


### PR DESCRIPTION
Following on from #387 I went through the `exercises` directory and amended any `description.md` files to be wrapped to 80 chars. The need for this was first discussed [#200 (comment)](https://github.com/exercism/x-common/pull/200#r55940147).

All files were identified via `git grep -El '.{81,}' exercises/*/description.md` per @petertseng instruction. As files were edited I tested them before and after an edit using [grip](https://github.com/joeyespo/grip). I can confirm that they all render correctly.

I edited the link in `exercises/protein-translation/description.md` to be create. It wasn't rendering correctly due to a missing ).

In #387 I provided a screen shot of the before and after. I think that doing this for PR would be overkill. 
