### PR TITLE
add test case for vowel plus 'qu'

### DIFF
--- a/exercises/pig-latin/canonical-data.json
+++ b/exercises/pig-latin/canonical-data.json
@@ -31,6 +31,11 @@
           "description" : "word beginning with u",
           "input" : "under",
           "expected" : "underay"
+        },
+        {
+          "description" : "word beginning with a vowel and followed by a qu",
+          "input" : "equal",
+          "expected" : "equalay"
         }
       ]
     },


### PR DESCRIPTION
A consonant+qu should be moved to the end of the word, but not a vowel+qu. I've added a test case for this, as I've seen multiple solutions where this rule wasn't followed exactly.