### PR TITLE
crypto-square: Clarifying how whitespace should be handled

### DIFF
--- a/exercises/crypto-square/description.md
+++ b/exercises/crypto-square/description.md
@@ -44,10 +44,12 @@ imtgdvsfearwermayoogoanouuiontnnlvtwttddesaohghnsseoau
 
 Output the encoded text in chunks.  Phrases that fill perfect squares
 `(r X r)` should be output in `r`-length chunks separated by spaces.
-Imperfect squares will have `n` empty spaces.  Those spaces should be distributed evenly across the last `n` rows.
+Imperfect squares will have `n` empty spaces.  The final row should
+not have any trailing whitespace instead of including `n` empty
+spaces at the end.
 
 ```plain
-imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn sseoau
+imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghns seoau
 ```
 
 Notice that were we to stack these, we could visually decode the
@@ -60,6 +62,6 @@ mayoogo
 anouuio
 ntnnlvt
 wttddes
-aohghn
-sseoau
+aohghns
+seoau
 ```


### PR DESCRIPTION
![It is hip to be square](http://i.giphy.com/wn4gdqoioxXIQ.gif)

I was a little confused by the description for how extra whitespace should be handled in the `crypto-square` problem. Based on the tests in the [xecmascript](https://github.com/exercism/xecmascript) instead of evenly spacing the extras whitespace across multiple rows, the whitespace appeared to be added to the final row.

I have updated the wording to try to better reflect how the whitespace was handled. Thank you for such an awesome project and being so open to contributions.