### PR TITLE
Fix bowling description text case and typo

### DIFF
--- a/exercises/bowling/canonical-data.json
+++ b/exercises/bowling/canonical-data.json
@@ -42,7 +42,7 @@
       "rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 3, 7],
       "expected": 17
     }, {
-      "description": "a strike earns ten points in frame with a single roll",
+      "description": "a strike earns ten points in a frame with a single roll",
       "rolls": [10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
       "expected": 10
     }, {
@@ -74,31 +74,31 @@
       "rolls": [10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10],
       "expected": 300
     }, {
-      "description": "Rolls can not score negative points",
+      "description": "rolls can not score negative points",
       "rolls": [-1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
       "expected": -1
     }, {
-      "description": "A roll can not score more than 10 points",
+      "description": "a roll can not score more than 10 points",
       "rolls": [11, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
       "expected": -1
     }, {
-      "description": "Two rolls in a frame can not score more than 10 points",
+      "description": "two rolls in a frame can not score more than 10 points",
       "rolls": [5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
       "expected": -1
     }, {
-      "description": "Two bonus rolls after a strike in the last frame can not score more than 10 points",
+      "description": "two bonus rolls after a strike in the last frame can not score more than 10 points",
       "rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 5, 6],
       "expected": -1
     }, {
-      "description": "An unstarted game can not be scored",
+      "description": "an unstarted game can not be scored",
       "rolls": [],
       "expected": -1
     }, {
-      "description": "An incomplete game can not be scored",
+      "description": "an incomplete game can not be scored",
       "rolls": [0, 0],
       "expected": -1
     }, {
-      "description": "A game with more than ten frames can not be scored",
+      "description": "a game with more than ten frames can not be scored",
       "rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
       "expected": -1
     }, {


### PR DESCRIPTION
I noticed some inconsistent casing in the test descriptions for this exercise. 