### PR TITLE
Grains: Add canonical-data.json file

### DIFF
--- a/exercises/grains/canonical-data.json
+++ b/exercises/grains/canonical-data.json
@@ -1,0 +1,66 @@
+{
+  "#": [
+    "The final tests of square test error conditions",
+    "The expection for these tests is -1, indicating an error",
+    "In these cases you should expect an error as is idiomatic for your language"
+  ],
+  "square": {
+    "description": "returns the number of grains on the square",
+    "cases": [
+      {
+        "description": "1",
+        "input": 1,
+        "expected": 1
+      },
+      {
+        "description": "2",
+        "input": 2,
+        "expected": 2
+      },
+      {
+        "description": "3",
+        "input": 3,
+        "expected": 4
+      },
+      {
+        "description": "4",
+        "input": 4,
+        "expected": 8
+      },
+      {
+        "description": "16",
+        "input": 16,
+        "expected": 32768
+      },
+      {
+        "description": "32",
+        "input": 32,
+        "expected": 2147483648
+      },
+      {
+        "description": "64",
+        "input": 64,
+        "expected": 9223372036854775808
+      },
+      {
+        "description": "square 0 raises an execption",
+        "input": 0,
+        "expected": -1
+      },
+      {
+        "description": "negative square raises an execption",
+        "input": -1,
+        "expected": -1
+      },
+      {
+        "description": "square greater than 64 raises an execption",
+        "input": 65,
+        "expected": -1
+      },
+    ]
+  },
+  "total": {
+    "description": "returns the total number of grains on the board",
+    "expected": 18446744073709551615
+  }
+}

--- a/exercises/grains/canonical-data.json
+++ b/exercises/grains/canonical-data.json
@@ -56,7 +56,7 @@
         "description": "square greater than 64 raises an execption",
         "input": 65,
         "expected": -1
-      },
+      }
     ]
   },
   "total": {


### PR DESCRIPTION
Current implementations of this exercise are all nearly identical, so
creating a canonical test set was just a matter of documenting the
existing tests.

Some languages do not include the error-handling tests, but I think they
are valuable to include as the boundaries they test are part of the
problem domain.