### PR TITLE
[bin/jsonlint] Add check for `jq` before running linter.

### DIFF
--- a/bin/jsonlint
+++ b/bin/jsonlint
@@ -1,8 +1,24 @@
 #!/usr/bin/env bash
 
+LINTER=jq
+INSTRUCTIONS_URL="https://stedolan.github.io/jq/download/"
+
+function command_exists() {
+	type "$1" &> /dev/null
+}
+
+function error_exit {
+	printf "$1" >&2
+	exit "${2:-1}"
+}
+
+if ! command_exists $LINTER; then
+	error_exit "'$LINTER' is not installed.\nSee $INSTRUCTIONS_URL for installation instructions.\n"
+fi
+
 STATUS=0
 for f in $(ls exercises/**/*.json); do
-	cat $f | jq . > /dev/null 2>&1
+	cat $f | $LINTER . > /dev/null 2>&1
 	if [ $? != 0 ]; then
 		echo "Invalid json: $f"
 		STATUS=1


### PR DESCRIPTION
During CI bin/jsonlint checks the validity of the exercise json files using the external `jq` program.

This patch checks that `jq` is installed and provides an error message and guidance on where to look for instructions on installing if it is not present.

This is useful if you try to run bin/jsonlint on your development system and do not already have `jq` installed.

Before:
Erroneous invalid json messages due to command failing due to lack of `jq` rather than because of invalid json.
```
$ bin/jsonlint 
Invalid json: exercises/acronym/canonical-data.json
<snip many many more messages like this.>
Invalid json: exercises/wordy/canonical-data.json
```

After:
```
$ bin/jsonlint 
'jq' is not installed.
See https://stedolan.github.io/jq/download/ for installation instructions.
```


