### PR TITLE
[Bowling] Add edge case with fill balls in a last-frame strike (Re-applies #418)

### DIFF
--- a/exercises/bowling/canonical-data.json
+++ b/exercises/bowling/canonical-data.json
@@ -15,7 +15,7 @@
   ],
   "score": {
     "description": [
-      "Returns the final score of a bowling game"
+      "returns the final score of a bowling game"
     ],
     "cases": [{
       "description": "should be able to score a game with all zeros",
@@ -88,6 +88,14 @@
     }, {
       "description": "two bonus rolls after a strike in the last frame can not score more than 10 points",
       "rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 5, 6],
+      "expected": -1
+    }, {
+      "description": "two bonus rolls after a strike in the last frame can score more than 10 points if one is a strike",
+      "rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10, 6],
+      "expected": 26
+    }, {
+      "description": "the second bonus rolls after a strike in the last frame can not be a strike if the first one is not a strike",
+      "rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 6, 10],
       "expected": -1
     }, {
       "description": "an unstarted game can not be scored",


### PR DESCRIPTION
Fixes the mess I made of @IanWhitney's PR: #418 

* Add edge case with fill balls in a last-frame strike

The previous test does not quite capture the behavior.

If the first fill fill is a non-strikes, then the total fill-ball score
must be less than 10.

But, if the first fill ball is a strike, then the total fill-ball score
must be less than 20. Because that first fill-ball strike resets the
pins.

I had what I thought was a working implementation but it totally missed
the 2nd case. Adding a test to cover that case.

* Add edge case test for final-strike fill balls

This test checks that the fill balls validate correctly if the 2nd ball
is a strike.