### PR TITLE
raindrops: include 1 and n in factor list in examples

### DIFF
--- a/exercises/raindrops/description.md
+++ b/exercises/raindrops/description.md
@@ -6,10 +6,10 @@
 
 ## Examples
 
-- 28's factors are 2, 4, **7**, 14.
+- 28's factors are 1, 2, 4, **7**, 14, 28.
   - In raindrop-speak, this would be a simple "Plong".
-- 30's factors are 2, **3**, **5**, 6, 15.
+- 30's factors are 1, 2, **3**, **5**, 6, 15, 30.
   - In raindrop-speak, this would be a "PlingPlang".
-- 34 only has two factors- 2 and 17.
+- 34 only has four factors: 1, 2, 17, and 34.
   - Raindrop-speak doesn't know what to make of that,
     so it just goes with the straightforward "34".

--- a/exercises/raindrops/description.md
+++ b/exercises/raindrops/description.md
@@ -10,6 +10,6 @@
   - In raindrop-speak, this would be a simple "Plong".
 - 30's factors are 1, 2, **3**, **5**, 6, 15, 30.
   - In raindrop-speak, this would be a "PlingPlang".
-- 34 only has four factors: 1, 2, 17, and 34.
+- 34 has four factors: 1, 2, 17, and 34.
   - Raindrop-speak doesn't know what to make of that,
     so it just goes with the straightforward "34".

--- a/exercises/raindrops/description.md
+++ b/exercises/raindrops/description.md
@@ -11,5 +11,4 @@
 - 30's factors are 1, 2, **3**, **5**, 6, 15, 30.
   - In raindrop-speak, this would be a "PlingPlang".
 - 34 has four factors: 1, 2, 17, and 34.
-  - Raindrop-speak doesn't know what to make of that,
-    so it just goes with the straightforward "34".
+  - In raindrop-speak, this would be "34".


### PR DESCRIPTION
i believe that technically 1 and n are always factors of number n.

but more importantly--not including them in the examples leads to failures in the tests.

`raindrops_test.go:14: Convert(3) = "3", expected "Pling".`

that is, one can say the factors of 3 are either--
`[]int{1, 3}`
or
`[]int{}`

the tests expect 3 to be in the factor list, so i think it makes sense to include 1 and n in the examples :)