### PR TITLE
food-chain: resolve ambiguity in multiple verses test

### DIFF
--- a/exercises/food-chain/canonical-data.json
+++ b/exercises/food-chain/canonical-data.json
@@ -106,13 +106,19 @@
             {
                 "description": "multiple verses",
                 "start verse": 1,
-                "end verse": 2,
+                "end verse": 3,
                 "expected": [
                     "I know an old lady who swallowed a fly.",
                     "I don't know why she swallowed the fly. Perhaps she'll die.",
                     "",
                     "I know an old lady who swallowed a spider.",
                     "It wriggled and jiggled and tickled inside her.",
+                    "She swallowed the spider to catch the fly.",
+                    "I don't know why she swallowed the fly. Perhaps she'll die.",
+                    "",
+                    "I know an old lady who swallowed a bird.",
+                    "How absurd to swallow a bird!",
+                    "She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.",
                     "She swallowed the spider to catch the fly.",
                     "I don't know why she swallowed the fly. Perhaps she'll die."
                 ]


### PR DESCRIPTION
The current test for multiple verses checks for two consecutive
verses (from 1 to 2) which leaves room for interpretation.

It is unclear whether the solution should simply concatenate two (or
more, when variadic functions are available) possibly non-consecutive
verses or return a range of consecutive verses from start to end. As
observed in the Go track, this ambiguity results in differing
solutions which makes them harder to compare.

This commit changes the multiple verses test to cover two non-
consecutive verses (1 and 3). With the change, only a solution
returning a range of consecutive verses is accepted.

See exercism/xgo#412