### PR TITLE
isogram: Revise canonical test data

### DIFF
--- a/exercises/isogram/canonical-data.json
+++ b/exercises/isogram/canonical-data.json
@@ -1,27 +1,44 @@
 {
-  "cases": [{
-    "input": "duplicates",
-    "expected": true
-  }, {
-    "input": "eleven",
-    "expected": false
-  }, {
-    "input": "subdermatoglyphic",
-    "expected": true
-  }, {
-    "input": "Alphabet",
-    "expected": false
-  }, {
-    "input": "thumbscrew-japingly",
-    "expected": true
-  }, {
-    "input": "Hjelmqvist-Gryb-Zock-Pfund-Wax",
-    "expected": true
-  }, {
-    "input": "the quick brown fox",
-    "expected": false
-  }, {
-    "input": "Emily Jung Schwartzkopf",
-    "expected": true
-  }]
+  "cases": [
+    {
+      "description": "empty string has no duplicates",
+      "input": "",
+      "expected": true
+    },
+    {
+      "description": "isogram with only lower case characters",
+      "input": "duplicates",
+      "expected": true
+    },
+    {
+      "description": "word with one duplicated character",
+      "input": "eleven",
+      "expected": false
+    },
+    {
+      "description": "longest reported english isogram",
+      "input": "subdermatoglyphic",
+      "expected": true
+    },
+    {
+      "description": "word with duplicated character in mixed case",
+      "input": "Alphabet",
+      "expected": false
+    },
+    {
+      "description": "hypothetical isogrammic word with hyphen",
+      "input": "thumbscrew-japingly",
+      "expected": true
+    },
+    {
+      "description": "isogram with duplicated non letter character",
+      "input": "Hjelmqvist-Gryb-Zock-Pfund-Wax",
+      "expected": true
+    },
+    {
+      "description": "made-up name that is an isogram",
+      "input": "Emily Jung Schwartzkopf",
+      "expected": true
+    }
+  ]
 }

--- a/exercises/isogram/canonical-data.json
+++ b/exercises/isogram/canonical-data.json
@@ -18,16 +18,10 @@
     "input": "Hjelmqvist-Gryb-Zock-Pfund-Wax",
     "expected": true
   }, {
-    "input": "Heizölrückstoßabdämpfung",
-    "expected": true
-  }, {
     "input": "the quick brown fox",
     "expected": false
   }, {
     "input": "Emily Jung Schwartzkopf",
     "expected": true
-  }, {
-    "input": "éléphant",
-    "expected": false
   }]
 }

--- a/exercises/isogram/canonical-data.json
+++ b/exercises/isogram/canonical-data.json
@@ -1,7 +1,7 @@
 {
   "cases": [
     {
-      "description": "empty string has no duplicates",
+      "description": "empty string",
       "input": "",
       "expected": true
     },

--- a/exercises/isogram/canonical-data.json
+++ b/exercises/isogram/canonical-data.json
@@ -7,7 +7,7 @@
     },
     {
       "description": "isogram with only lower case characters",
-      "input": "duplicates",
+      "input": "isogram",
       "expected": true
     },
     {


### PR DESCRIPTION
This removes the two unicode test cases as discussed in #428. One test case was an isogram with German umlauts, the other one was a French word with a duplicated character with accent (also non-ASCII). I don't think we loose anything here without those test cases that isn't covered by the remaining ones.

I also added descriptions for the test cases and a test case with an empty string. *If you would prefer those non unicode changes in a separate PR, just ask.*