### PR TITLE
run-length-encoding: Remove non-ASCII test cases

### DIFF
--- a/exercises/run-length-encoding/canonical-data.json
+++ b/exercises/run-length-encoding/canonical-data.json
@@ -1,6 +1,6 @@
 {
    "#": [
-   	  "The tests deliberately check that single characters are encoded without count."
+      "The tests deliberately check that single characters are encoded without count."
    ],
    "cases": [
       {
@@ -27,16 +27,6 @@
         "description": "decode(encode(...)) combination",
         "input": "zzz ZZ  zZ",
         "expected": "zzz ZZ  zZ"
-      },
-      {
-        "description": "encode unicode",
-        "input": "⏰⚽⚽⚽⭐⭐⏰",
-        "expected": "⏰3⚽2⭐⏰"
-      },
-      {
-        "description": "decode unicode",
-        "input": "⏰3⚽2⭐⏰",
-        "expected": "⏰⚽⚽⚽⭐⭐⏰"
       }
    ]
 }


### PR DESCRIPTION
This removes the two unicode test cases as discussed in #428.

I also added one test case with an empty string and one with only chars that occur once. *If you would prefer those non unicode changes in a separate PR, just ask.*