### PR TITLE
pangram: Remove non-ascii test cases.

### DIFF
--- a/exercises/pangram/canonical-data.json
+++ b/exercises/pangram/canonical-data.json
@@ -39,16 +39,6 @@
         "description": "pangram with mixed case and punctuation",
         "input": "\"Five quacking Zephyrs jolt my wax bed.\"",
         "expected": true
-      },
-      {
-        "description": "pangram with non ascii characters",
-        "input": "Victor jagt zwölf Boxkämpfer quer über den großen Sylter Deich.",
-        "expected": true
-      },
-      {
-         "description": "Panagram in alphabet other than ASCII",
-         "input": "Широкая электрификация южных губерний даст мощный толчок подъёму сельского хозяйства.",
-         "expected": false
       }
    ]
 }


### PR DESCRIPTION
In https://github.com/exercism/x-common/issues/428 the decision was made
to remove non-ascii test cases from exercises that are not explicitly
about extended character set handling.

This PR removes the non-ascii test cases from the `canonical_data.json`
for this exercise.