### PR TITLE
bowling: Add tests for more than 10 after last frame

### DIFF
--- a/exercises/bowling/canonical-data.json
+++ b/exercises/bowling/canonical-data.json
@@ -86,6 +86,10 @@
       "rolls": [5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
       "expected": -1
     }, {
+      "description": "bonus roll after a strike in the last frame can not score more than 10 points",
+      "rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 11],
+      "expected": -1
+    }, {
       "description": "two bonus rolls after a strike in the last frame can not score more than 10 points",
       "rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 5, 6],
       "expected": -1
@@ -96,6 +100,10 @@
     }, {
       "description": "the second bonus rolls after a strike in the last frame can not be a strike if the first one is not a strike",
       "rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 6, 10],
+      "expected": -1
+    }, {
+      "description": "second bonus roll after a strike in the last frame can not score than 10 points",
+      "rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10, 11],
       "expected": -1
     }, {
       "description": "an unstarted game can not be scored",


### PR DESCRIPTION
We have tests for:

* Rolling 11 in a single roll
* Rolling 5 then 6
* Rolling 5 then 6 after a last-frame strike

So it appears we are missing the test for rolling an 11 after a
last-frame strike. Let's add it.