### PR TITLE
Add descriptions for the raindrops tests.

### DIFF
--- a/exercises/raindrops/canonical-data.json
+++ b/exercises/raindrops/canonical-data.json
@@ -26,7 +26,7 @@
          "expected": "Pling"
       },
       {
-        "description" : "the sound for 8 is 8",
+        "description" : "2 to the power 3 does not make a raindrop sound as 3 is the exponent not the base",
         "number" : 8,
         "expected": "8"
       },
@@ -41,7 +41,7 @@
          "expected": "Plang"
       },
       {
-         "description" : "the sound for 14 is Plong",
+         "description" : "the sound for 14 is Plong as it has a factor of 7",
          "number" : 14,
          "expected": "Plong"
       },

--- a/exercises/raindrops/canonical-data.json
+++ b/exercises/raindrops/canonical-data.json
@@ -1,74 +1,92 @@
 {
    "cases": [
       {
+         "description" : "the sound for 1 is 1",
          "number" : 1,
          "expected": "1"
       },
       {
+         "description" : "the sound for 3 is Pling",
          "number" : 3,
          "expected": "Pling"
       },
       {
+         "description" : "the sound for 5 is Plang",
          "number" : 5,
          "expected": "Plang"
       },
       {
+         "description" : "the sound for 7 is Plong",
          "number" : 7,
          "expected": "Plong"
       },
       {
+         "description" : "the sound for 6 is Pling as it has a factor 3",
          "number" : 6,
          "expected": "Pling"
       },
       {
+        "description" : "the sound for 8 is 8",
         "number" : 8,
         "expected": "8"
       },
       {
+         "description" : "the sound for 9 is Pling as it has a factor 3",
          "number" : 9,
          "expected": "Pling"
       },
       {
+         "description" : "the sound for 10 is Plang as it has a factor 5",
          "number" : 10,
          "expected": "Plang"
       },
       {
+         "description" : "the sound for 14 is Plong",
          "number" : 14,
          "expected": "Plong"
       },
       {
+         "description" : "the sound for 15 is PlingPlang as it has factors 3 and 5",
          "number" : 15,
          "expected": "PlingPlang"
       },
       {
+         "description" : "the sound for 21 is PlingPlong as it has factors 3 and 7",
          "number" : 21,
          "expected": "PlingPlong"
       },
       {
+         "description" : "the sound for 25 is Plang as it has a factor 5",
          "number" : 25,
          "expected": "Plang"
       },
       {
+         "description" : "the sound for 27 is Pling as it has a factor 3",
          "number" : 27,
          "expected": "Pling"
       },
       {
+         "description" : "the sound for 35 is PlangPlong as it has factors 5 and 7",
          "number" : 35,
          "expected": "PlangPlong"
       },
       {
+         "description" : "the sound for 49 is Plong as it has a factor 7",
          "number" : 49,
          "expected": "Plong"
       },
       {
+         "description" : "the sound for 52 is 52",
          "number" : 52,
          "expected": "52"
       },
       {
+         "description" : "the sound for 105 is PlingPlangPlong as it has factors 3, 5 and 7",
          "number" : 105,
          "expected": "PlingPlangPlong"
       },
       {
+        "description" : "the sound for 3125 is Plang as it has a factor 5",
         "number" : 3125,
         "expected": "Plang"
       }


### PR DESCRIPTION
Unlike the other canonical-data I have seen, the tests have no description.
I'm writing a test generator for the xocaml stream - it fails due to this.