### PR TITLE
minesweeper: remove number from input, add mines

### DIFF
--- a/exercises/minesweeper/canonical-data.json
+++ b/exercises/minesweeper/canonical-data.json
@@ -56,9 +56,9 @@
     {
       "description": "space surrounded by mines",
       "input": [
-        "   ",
-        " 8 ",
-        "   "
+        "***",
+        "* *",
+        "***"
       ],
       "expected": [
         "***",


### PR DESCRIPTION
an input containing only "8" implies that the student solution is
supposed to read a board with numbers and fill in the mines, which is
contrary to all other tests (read a board with mines, fill in the
numbers)