### PR TITLE
variable-length-quantity: Limit to 32-bit int, not 28-bit int

### DIFF
--- a/exercises/variable-length-quantity/description.md
+++ b/exercises/variable-length-quantity/description.md
@@ -8,7 +8,7 @@ To indicate which is the last byte of the series, you leave bit #7 clear.
 In all of the preceding bytes, you set bit #7. 
 
 So, if an integer is between `0-127`, it can be represented as one byte. 
-The largest integer allowed is `0FFFFFFF`, which translates to 4 bytes variable length. 
+Although VLQ can deal with numbers of arbitrary sizes, for this exercise we will restrict ourselves to only numbers that fit in a 32-bit unsigned integer.
 Here are examples of integers as 32-bit values, and the variable length quantities that they translate to:
 
 

--- a/exercises/variable-length-quantity/description.md
+++ b/exercises/variable-length-quantity/description.md
@@ -9,7 +9,7 @@ In all of the preceding bytes, you set bit #7.
 
 So, if an integer is between `0-127`, it can be represented as one byte. 
 The largest integer allowed is `0FFFFFFF`, which translates to 4 bytes variable length. 
-Here are examples of delta-times as 32-bit values, and the variable length quantities that they translate to:
+Here are examples of integers as 32-bit values, and the variable length quantities that they translate to:
 
 
 ```


### PR DESCRIPTION
### variable-length-quantity: s/delta-time/integer/

delta-time seems to only be meaningful in the context of MIDIs. We are
dealing with just arbitrary integers, with no mention of domain.

### variable-length-quantity: Limit to 32-bit int, not 28-bit int

The limit of a 28-bit int (0x0fffffff) is specific to MIDIs, whereas
variable-length quantities can deal with arbitrary sizes.

So why limit to 32-bits? Because it is a common size for languages, and
some language tracks already have tests that assume that the limit is
0xffffffff, so we might as well match them.

Closes #485
Closes exercism/xrust#224