### PR TITLE
secret-handshake: Add canonical data (revives #159)

### DIFF
--- a/exercises/secret-handshake/canonical-data.json
+++ b/exercises/secret-handshake/canonical-data.json
@@ -1,0 +1,67 @@
+{
+    "commands": {
+        "description": ["Create a handshake for a number"],
+        "cases": [
+            {
+                "description": "wink for 1",
+                "input": 1,
+                "expected": ["wink"]
+            },
+            {
+                "description": "double blink for 10",
+                "input": 2,
+                "expected": ["double blink"]
+            },
+            {
+                "description": "close your eyes for 100",
+                "input": 4,
+                "expected": ["close your eyes"]
+            },
+            {
+                "description": "jump for 1000",
+                "input": 8,
+                "expected": ["jump"]
+            },
+            {
+                "description": "combine two actions",
+                "input": 3,
+                "expected": ["wink", "double blink"]
+            },
+            {
+                "description": "reverse two actions",
+                "input": 19,
+                "expected": ["double blink", "wink"]
+            },
+            {
+                "description": "reversing one action gives the same action",
+                "input": 24,
+                "expected": ["jump"]
+            },
+            {
+                "description": "reversing no actions still gives no actions",
+                "input": 16,
+                "expected": []
+            },
+            {
+                "description": "all possible actions",
+                "input": 15,
+                "expected": ["wink", "double blink", "close your eyes", "jump"]
+            },
+            {
+                "description": "reverse all possible actions",
+                "input": 31,
+                "expected": ["jump", "close your eyes", "double blink", "wink"]
+            },
+            {
+                "description": "do nothing for zero",
+                "input": 0,
+                "expected": []
+            },
+            {
+                "description": "do nothing if lower 5 bits not set",
+                "input": 32,
+                "expected": []
+            }
+        ]
+    }
+}

--- a/exercises/secret-handshake/description.md
+++ b/exercises/secret-handshake/description.md
@@ -16,12 +16,10 @@ binary decide to come up with a secret "handshake".
 
 Here's a couple of examples:
 
-Given the input 9, the function would return the array
-["wink", "jump"]
+Given the input 3, the function would return the array
+["wink", "double blink"] because 3 is 11 in binary.
 
-Given the input "11001", the function would return the array
-["jump", "wink"]
-
-
-The program should consider strings specifying an invalid binary as the
-value 0.
+Given the input 19, the function would return the array
+["double blink", "wink"] because 19 is 10011 in binary.
+Notice that the addition of 16 (10000 in binary)
+has caused the array to be reversed.


### PR DESCRIPTION
The time has come to help the abandoned #159 get merged.

Implementing tracks:

* https://github.com/exercism/xcsharp/blob/master/exercises/secret-handshake/SecretHandshakeTest.cs
* https://github.com/exercism/xecmascript/blob/master/exercises/secret-handshake/secret-handshake.spec.js
* https://github.com/exercism/xfsharp/blob/master/exercises/secret-handshake/SecretHandshakeTest.fs
* https://github.com/exercism/xgo/blob/master/exercises/secret-handshake/secret_handshake_test.go
* https://github.com/exercism/xhaskell/blob/master/exercises/secret-handshake/test/Tests.hs
* https://github.com/exercism/xjavascript/blob/master/exercises/secret-handshake/secret-handshake.spec.js
* https://github.com/exercism/xlua/blob/master/exercises/secret-handshake/secret-handshake_spec.lua
* https://github.com/exercism/xobjective-c/blob/master/exercises/secret-handshake/SecretHandshakeTest.m
* https://github.com/exercism/xperl5/blob/master/exercises/secret-handshake/handshake.t
* https://github.com/exercism/xpython/blob/master/exercises/secret-handshake/handshake_test.py
* https://github.com/exercism/xruby/blob/master/exercises/secret-handshake/secret_handshake_test.rb
* https://github.com/exercism/xscala/blob/master/exercises/secret-handshake/src/test/scala/SecretHandshakeTest.scala
* https://github.com/exercism/xswift/blob/master/exercises/secret-handshake/SecretHandshakeTest.swift

Summary of tests among these languages:

* All language tracks test: 1, 2, 4, 8, 3, 19, 31.
* Go, Haskell, Objective C, Scala, and Swift additionally test 0.
* Go is the only track that tests 32, 33.
* Python is the only track that tests 9, 22, 5, -9.
* Python is the only track that tests action -> number conversions.
* Haskell, Python, and Scala test strings (string binary -> number conversion)
* ECMAScript and JavaScript test strings (only that strings are rejected)
* Perl and Ruby test strings (that they are accepted but result in an empty array)

Closes #159 by way of replacement.
Closes exercism/todo#145