### PR TITLE
CONTRIBUTING: remind about adding to config.json

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -337,7 +337,12 @@ The exercise should consist of, at minimum:
 * A test suite
 * A reference solution that passes the test (see [#reference-solution](#reference-solution))
 
-Each language track might have additional requirements; check the README in
+You will need to add the exercise to `"exercises"` section of the `config.json` file in the track.
+The order in which the exercises are listed there is the order in which they are fetched by default by `exercism fetch`.
+Typically, exercises are ordered by difficulty, unless there is a particular reason to do otherwise.
+
+Each language track might have additional guidance on how to order their
+exercises or additional requirements on new exercise files; check the README in
 the repository for the track.
 
 ### Providing Feedback on the Site for an Exercise You Implemented


### PR DESCRIPTION
In various tracks, I sometimes see contributors forget to do this, and
perhaps one cause is that the requirement isn't mentioned here (various
tracks link to this document to explain how to port an exercise to their
track).

Luckily, this gets caught by configlet (assuming the track is running
Travis CI and hasn't removed configlet), but it would be good to let
contributors to know of this up front.

Decision: This text explcitly mentions the `"exercises"` key, rather
than the deprecated `"problems"` key.

The following procedure:

    gem install trackler --ignore-dependencies
    # substitute your Ruby version for $RUBY_VERSION
    grep -L exercises ~/.gem/ruby/$RUBY_VERSION/gems/trackler-2.0.6.10/tracks/*/config.json

says that only two tracks lack the `exercises` key: Ceylon and PL/SQL

* a PR https://github.com/exercism/xplsql/pull/16 is open for PL/SQL
* a PR https://github.com/exercism/xceylon/pull/8 has already been
  merged in Ceylon and will go out in the next Trackler update.

Therefore, it almost certainly safe to use the `exercises` key!

One weakness is that this text doesn't explicitly mention the `slug` or
`difficulty` or `topics` keys for each entry in the `exercises` array.
This weakness is currently mitigated by the fact that active languages
should have many examples to go off of. The only time where there are no
examples will be when starting a brand-new track.