### PR TITLE
Luhn: Update test of non-digit

### DIFF
--- a/exercises/luhn/canonical-data.json
+++ b/exercises/luhn/canonical-data.json
@@ -26,7 +26,7 @@
       "expected": false
     },
     {
-      "description": "strings that contain non-digits are not valid",
+      "description": "valid strings with a non-digit added become invalid",
       "input": "046a 454 286",
       "expected": false
     }

--- a/exercises/luhn/canonical-data.json
+++ b/exercises/luhn/canonical-data.json
@@ -27,7 +27,7 @@
     },
     {
       "description": "strings that contain non-digits are not valid",
-      "input": "827a 1232 7352 0569",
+      "input": "046a 454 286",
       "expected": false
     }
   ]


### PR DESCRIPTION
While implementing these tests for Rust I found that the final test was
not well written (my fault!)

https://github.com/exercism/xrust/pull/247

I added the alphabetical character to an already-invalid string. So the
test doesn't show anything useful.

Instead the test should show that a known-valid string is made invalid
by the inclusion of a non-digit