### PR TITLE
rectangles: update with 1xN, Nx1, 1x1 cases

### DIFF
--- a/exercises/rectangles/canonical-data.json
+++ b/exercises/rectangles/canonical-data.json
@@ -51,6 +51,31 @@
       "expected": 5
     },
     {
+      "description": "rectangle of height 1 is counted",
+      "input": [
+        "+--+",
+        "+--+"
+      ],
+      "expected": 1
+    },
+    {
+      "description": "rectangle of width 1 is counted",
+      "input": [
+        "++",
+        "||",
+        "++"
+      ],
+      "expected": 1
+    },
+    {
+      "description": "1x1 square is counted",
+      "input": [
+        "++",
+        "++"
+      ],
+      "expected": 1
+    },
+    {
       "description": "only complete rectangles are counted",
       "input": [
         "  +-+",

--- a/exercises/rectangles/description.md
+++ b/exercises/rectangles/description.md
@@ -2,13 +2,13 @@ Create a program to count the rectangles in an ASCII diagram like the one below.
 
 ```
    +--+
-   |  |
-+--+--+
+  ++  |
++-++--+
 |  |  |
 +--+--+
 ```
 
-The above diagram contains 5 rectangles:
+The above diagram contains 6 rectangles:
 
 ```
 
@@ -48,6 +48,14 @@ The above diagram contains 5 rectangles:
 +--+
 |  |
 +--+
+```
+
+```
+       
+  ++   
+  ++   
+       
+       
 ```
 
 You may assume that the input is always a proper rectangle (i.e. the length of


### PR DESCRIPTION
In the final canonical test case for this exercise, we count rectangles whose sides have length 1. Such rectangles have slightly odd-looking representations:

```
++
++
```

```
+-+
+-+
```

```
++
||
++
```

etc.

I updated the example to include a rectangle of this type to avoid an unpleasant surprise at the end of the exercise. Thoughts?