### PR TITLE
lens: mark as immutable-data-specific, not Haskell specific

### DIFF
--- a/exercises/lens-person/metadata.yml
+++ b/exercises/lens-person/metadata.yml
@@ -1,5 +1,5 @@
 ---
-blurb: "(Haskell specific) use lenses to update nested records."
+blurb: "Use lenses to update nested records (specific to languages with immutable data)."
 common:
     type: focus
     focus: lenses


### PR DESCRIPTION
At the time it was added (#97), indeed [Haskell][haskell] was the only
implementing track, and it was marked Haskell-specific.

However, the [Scala][scala] track has also implemented this exercise.
I predict it is confusing for Scala students to see "Haskell specific"
in the list of the Scala exercises. The proposal is to change it to
"specific to languages with immutable data".

[haskell]: https://github.com/exercism/xhaskell/pull/84
[scala]: https://github.com/exercism/xscala/pull/157

Lenses can be a fit for any language that has immutable data and data
structures that can be nested.

In such a language, updating a deeply-nested field can be a lot of work,
but made easier with lenses. This exercise demonstrates the use of
lenses and is applicable to **any** language with immutable data, not
just Haskell.

The alternative considered was to use "functional programming" specific,
but the term "functional programming" is a little too broad. It's
altogether possible that a functional programming language could have
mutable data and a non-functional programming language could have
immutable data, so let's be precise about where lenses are helpful.

As of this writing, I do not believe any other exercise is
language-specific. Questions to this effect have been asked in:

* #352
* https://github.com/exercism/exercism.io/issues/3113

If you are curious about having language-specific exercises, you may be
interested in https://github.com/exercism/trackler/issues/22.
