### PR TITLE
etl: Add canonical data

### DIFF
--- a/exercises/etl/canonical-data.json
+++ b/exercises/etl/canonical-data.json
@@ -1,5 +1,12 @@
 {
   "transform": {
+    "#": [
+	"Note:  The expected input data for these tests should have",
+        "integer keys (not stringified numbers as shown in the JSON below",
+        "Unless the language prohibits that, please implement these tests",
+        "such that keys are integers. e.g. in JavaScript, it might look ",
+        "like `transform( { 1: ['A'] } );`"
+    ],
     "description": "transforms the a set of scrabble data previously indexed by the tile score to a set of data indexed by the tile letter",
     "cases": [
       {

--- a/exercises/etl/canonical-data.json
+++ b/exercises/etl/canonical-data.json
@@ -1,0 +1,62 @@
+{
+  "transform": {
+    "description": "transforms the a set of scrabble data previously indexed by the tile score to a set of data indexed by the tile letter",
+    "cases": [
+      {
+        "description": "a single letter",
+        "input": {
+          "1": ["A"]
+        },
+        "expected": {
+          "a" : 1
+        }
+      },
+      {
+        "description": "single score with multiple letters",
+        "input": {
+          "1": ["A", "E", "I", "O", "U" ]
+        },
+        "expected": {
+          "a" : 1,
+          "e" : 1,
+          "i" : 1,
+          "o" : 1,
+          "u" : 1
+        }
+      },
+      {
+        "description": "multiple scores with multiple letters",
+        "input": {
+          "1": ["A", "E"],
+          "2": ["D", "G"]
+        },
+        "expected": {
+          "a" : 1,
+          "e" : 1,
+          "d" : 2,
+          "g" : 2
+        }
+      },
+      {
+        "description": "multiple scores with differing numbers of letters",
+        "input": {
+          "1": [ "A", "E", "I", "O", "U", "L", "N", "R", "S", "T" ],
+          "2": [ "D", "G" ],
+          "3": [ "B", "C", "M", "P" ],
+          "4": [ "F", "H", "V", "W", "Y" ],
+          "5": [ "K" ],
+          "8": [ "J", "X" ],
+          "10": [ "Q", "Z" ]
+        },
+        "expected": {
+          "a": 1, "b": 3,  "c": 3, "d": 2, "e": 1,
+          "f": 4, "g": 2,  "h": 4, "i": 1, "j": 8,
+          "k": 5, "l": 1,  "m": 3, "n": 1, "o": 1,
+          "p": 3, "q": 10, "r": 1, "s": 1, "t": 1,
+          "u": 1, "v": 4,  "w": 4, "x": 8, "y": 4,
+          "z": 10
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
After scouring the existing test suites, I noticed that a few of them [Python, for example] (https://github.com/exercism/xpython/blob/master/exercises/etl/etl_test.py) include keys that are not just single letters but words.  I've included one extra case at the bottom that tests that case.  Not sure if it's something we want to include here or not.