### PR TITLE
prime-factors: add canonical data

### DIFF
--- a/exercises/prime-factors/canonical-data.json
+++ b/exercises/prime-factors/canonical-data.json
@@ -1,0 +1,42 @@
+{
+  "for": {
+    "description": "returns prime factors for the given input number",
+    "cases": [
+      {
+        "description" : "no factors",
+        "input" : 1,
+        "expected" : []
+      },
+      {
+        "description" : "prime number",
+        "input" : 2,
+        "expected" : [2]
+      },
+      {
+        "description" : "square of a prime",
+        "input" : 9,
+        "expected" : [3, 3]
+      },
+      {
+        "description" : "cube of a prime",
+        "input" : 8,
+        "expected" : [2, 2, 2]
+      },
+      {
+        "description" : "product of primes and non-primes",
+        "input" : 12,
+        "expected" : [2, 2, 3]
+      },
+      {
+        "description" : "product of primes",
+        "input" : 901255,
+        "expected" : [5, 17, 23, 461]
+      },
+      {
+        "description" : "factors include a large prime",
+        "input" : 93819012551,
+        "expected" : [11, 9539, 894119]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Added canonical-data.json for the prime factors exercise [exercise description here](https://github.com/exercism/x-common/blob/master/exercises/prime-factors/description.md).

Addresses https://github.com/exercism/todo/issues/129