### PR TITLE
scrabble-score: add alphabet completeness test

### DIFF
--- a/exercises/scrabble-score/canonical-data.json
+++ b/exercises/scrabble-score/canonical-data.json
@@ -54,6 +54,11 @@
       "description": "empty input",
       "input": "",
       "expected": 0
+    },
+    {
+      "description": "entire alphabet available",
+      "input": "abcdefghijklmnopqrstuvwxyz",
+      "expected": 87
     }
   ]
 }


### PR DESCRIPTION
After the discussion in #509 , here is proposed addition to the canonical data.
Feel free to pick nits!

If we really wish to stick to "proper, scrabble-approved word", I could make multiple cases for 
"the" 
"quick"
"brown"
"fox"
"jumps"
"over"
"lazy"
"dog"

But in my personal opinion that obscures the intended purpose. The complete alphabet is the shortest way to express the complete alphabet, and thereby makes the intent the clearest. Anything else just muddles the waters (IMHO).