### PR TITLE
RFC: hello-world: remove reference to "name not given"

### DIFF
--- a/exercises/hello-world/canonical-data.json
+++ b/exercises/hello-world/canonical-data.json
@@ -1,14 +1,5 @@
 {
-   "#": [
-     "Language implementations vary on the issue of missing input variables.",
-     "In this set of test cases, the input variable is left out of the definition,",
-     "and the generator would need to handle the language implementation."
-   ],
    "cases": [
-      {
-         "description": "no name",
-         "expected": "Hello, World!"
-      },
       {
          "description": "sample name",
          "name": "Alice",
@@ -16,8 +7,8 @@
       },
       {
          "description": "other sample name",
-         "name": "Bob",
-         "expected": "Hello, Bob!"
+         "name": "World",
+         "expected": "Hello, World!"
       }
    ]
 }

--- a/exercises/hello-world/description.md
+++ b/exercises/hello-world/description.md
@@ -7,12 +7,10 @@ the traditional first program for beginning programming in a new language.
 
 ## Specification
 
-Write a `Hello World!` function that can greet someone given their name.  The
-function should return the appropriate greeting.
+Write a `Hello World!` function that can greet the world or a specific person.
+The function should return the appropriate greeting.
 
 For an input of "Alice", the response should be "Hello, Alice!".
-
-If a name is not given, the response should be "Hello, World!"
 
 ## Test-Driven Development
 


### PR DESCRIPTION

This implements the second option "change the hello-world README to be
so vague..." of #520.

As stated in #520, the point of hello-world is to give a very easy
exercise. This helps give an intro to how to fetch, how to submit, and
how to run the test suite for a given language. The README included with
hello-world helps out with that.

The clause "If a name is not given" is very difficult for languages that
do not support overloading functions and/or default function parameters.

This is against the vision of a very easy hello-world. The ideal is a
function that returns "Hello, World!" unconditionally.

By not mentioning the "name not given" in the README, every track that
currently has a hello-world exercise can change it or not, as they
please.

This is a very delicate balance to strike. If we make it too vague, that
is also undesirable. See #322. I cannot be sure that I have gotten it
right in this commit.