### PR TITLE
List Ops: add canonical data

### DIFF
--- a/exercises/list-ops/canonical-data.json
+++ b/exercises/list-ops/canonical-data.json
@@ -1,0 +1,147 @@
+{
+  "#": [
+    "Though there are no specifications here for dealing with large lists,",
+    "implementers may add tests for handling large lists to ensure that the",
+    "solutions have thought about performance concerns."
+  ],
+  "append": {
+    "description": "append entries to a list and return the new list",
+    "cases": [
+      {
+        "description": "empty lists",
+        "list1": [],
+        "list2": [],
+        "expected": []
+      },
+      {
+        "description": "empty list to list",
+        "list1": [],
+        "list2": [1,2,3,4],
+        "expected": [1,2,3,4]
+      },
+      {
+        "description": "non-empty lists",
+        "list1": [1,2],
+        "list2": [2,3,4,5],
+        "expected": [1,2,2,3,4,5]
+      }
+    ]
+  },
+  "concat": {
+    "description": "concat lists and lists of list into a new list",
+    "cases": [
+      {
+        "description": "empty list",
+        "lists": [],
+        "expected": []
+      },
+      {
+        "description": "list of lists",
+        "lists": [[1,2],[3],[],[4,5,6]],
+        "expected": [1,2,3,4,5,6]
+      }
+    ]
+  },
+  "filter": {
+    "description": "filter list returning only values that satisfy the filter function",
+    "cases": [
+      {
+        "description": "empty list",
+        "list": [],
+        "function": "value modulo 2 == 1",
+        "expected": []
+      },
+      {
+        "description": "non-empty list",
+        "list": [1,2,3,5],
+        "function": "value modulo 2 == 1",
+        "expected": [1,3,5]
+      }
+    ]
+  },
+  "length": {
+    "description": "returns the length of a list",
+    "cases": [
+      {
+        "description": "empty list",
+        "list": [],
+        "expected": 0
+      },
+      {
+        "description": "non-empty list",
+        "list": [1,2,3,4],
+        "expected": 4
+      }
+    ]
+  },
+  "map": {
+    "description": "return a list of elements whos values equal the list value transformed by the mapping function",
+    "cases": [
+      {
+        "description": "empty list",
+        "list": [],
+        "function": "value + 1",
+        "expected": []
+      },
+      {
+        "description": "non-empty list",
+        "list": [1,3,5,7],
+        "function": "value + 1",
+        "expected": [2,4,6,8]
+      }
+    ]
+  },
+  "foldl": {
+    "description": "folds (reduces) the given list from the left with a function",
+    "cases": [
+      {
+        "description": "empty list",
+        "list": [],
+        "initial": 2,
+        "function": "value / accumulator",
+        "expected": 2
+      },
+      {
+        "description": "division of integers",
+        "list": [1,2,3,4],
+        "initial": 24,
+        "function": "value / accumulator",
+        "expected": 64
+      }
+    ]
+  },
+  "foldr": {
+    "description": "folds (reduces) the given list from the right with a function",
+    "cases": [
+      {
+        "description": "empty list",
+        "list": [],
+        "initial": 2,
+        "function": "value / accumulator",
+        "expected": 2
+      },
+      {
+        "description": "division of integers",
+        "list": [1,2,3,4],
+        "initial": 24,
+        "function": "value / accumulator",
+        "expected": 9
+      }
+    ]
+  },
+  "reverse": {
+    "description": "reverse the elements of the list",
+    "cases": [
+      {
+        "description": "empty list",
+        "list": [],
+        "expected": []
+      },
+      {
+        "description": "non-empty list",
+        "list": [1,3,5,7],
+        "expected": [7,5,3,1]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Problem description [here](https://github.com/exercism/x-common/blob/master/exercises/list-ops/description.md) - albeit brief.

This is a first cut submit.  It most certainly needs revision.  If we can answer the following questions, I think I can make a second revision that should be pretty good.

Things to think about:
* Is the function representation clear enough? - see this discussed here: https://github.com/exercism/todo/issues/152#issuecomment-275889363
* Do we need to represent `foldl` and `foldr` in tests or is `reduce` sufficent?  After looking through 8 test suites from the existing implementations I found the following
* Many suites cover very large lists (0..100000) but that seems unreasonable to write into a json file... `"list": [0,1,2,3,4... lots more ... 99999, 100000]` ... so do those tests not show up here?  or do we include a comment (which i've done)?

| method | freq in sampled test suites |
| ------- | -----------------------|
| append | 6 |
| concat | 8|
| filter  | 7 |
| length/count | 8 |
| map | 8 |
| reverse | 8 |
| foldl & foldr | 5 |
| reduce | 3 |


Closes: https://github.com/exercism/todo/issues/109