### PR TITLE
food-chain: remove repeated blurb text from README

### DIFF
--- a/exercises/food-chain/description.md
+++ b/exercises/food-chain/description.md
@@ -1,5 +1,4 @@
-Generate the lyrics to the song "I know an old lady who
-swallowed a fly". While you could copy/paste the lyrics,
+While you could copy/paste the lyrics,
 or read them from a file, this problem is much more
 interesting if you approach it algorithmically.
 


### PR DESCRIPTION
Previously, the README contained duplicate text of the blub from [metadata.yml](https://github.com/exercism/x-common/blob/master/exercises/food-chain/metadata.yml#L2):
![image](https://cloud.githubusercontent.com/assets/5385846/22585468/8ac3ddfe-ea2a-11e6-87b5-e857df9d3379.png)

This fix removes the identical blub text from the README.