### PR TITLE
change: Add case for target > coins, but still can't make

### DIFF
--- a/exercises/change/canonical-data.json
+++ b/exercises/change/canonical-data.json
@@ -49,6 +49,12 @@
                 "expected": -1
             },
             {
+                "description": "error if no combination can add up to target",
+                "coins": [5, 10],
+                "target": 94,
+                "expected": -1
+            },
+            {
                 "description": "cannot find negative change values",
                 "coins": [1, 2, 5],
                 "target": -5,


### PR DESCRIPTION
The current error cases ask us to ensure that two types of targets are
invalid:
* targets smaller than the smallest coin
* negative targets

These are both reasonable.

I would react with chagrin if this led student solutions to assume that
these are the only two cases in which one could fail to meet the target
i.e. they assume that any target > the smallest coin is valid.

This commit proposes adding a case that disproves that - the target is
larger than even the largest coin, but you will not be able to get a
combination that reaches the target.