### PR TITLE
hello-world: Change to always expect "Hello, World!"

### DIFF
--- a/exercises/hello-world/canonical-data.json
+++ b/exercises/hello-world/canonical-data.json
@@ -1,23 +1,11 @@
 {
-   "#": [
-     "Language implementations vary on the issue of missing input variables.",
-     "In this set of test cases, the input variable is left out of the definition,",
-     "and the generator would need to handle the language implementation."
-   ],
-   "cases": [
-      {
-         "description": "no name",
-         "expected": "Hello, World!"
-      },
-      {
-         "description": "sample name",
-         "name": "Alice",
-         "expected": "Hello, Alice!"
-      },
-      {
-         "description": "other sample name",
-         "name": "Bob",
-         "expected": "Hello, Bob!"
-      }
-   ]
+  "exercise":"hello-world",
+  "version":"0.1.0",
+  "cases":[
+    {
+      "description":"Say Hi!",
+      "property":"hello",
+      "expected":"Hello, World!"
+    }
+  ]
 }

--- a/exercises/hello-world/description.md
+++ b/exercises/hello-world/description.md
@@ -1,46 +1,11 @@
 ["Hello, World!"](http://en.wikipedia.org/wiki/%22Hello,_world!%22_program) is
-the traditional first program for beginning programming in a new language.
+the traditional first program for beginning programming in a new language
+or environment.
 
-**Note:** You can skip this exercise by running:
+The objectives are simple:
 
-    exercism skip $TRACK_ID hello-world
+- Write a function that says "Hello, World!".
+- Run the test suite and make sure that it succeeds.
+- Submit your solution and check it at the website.
 
-## Specification
-
-Write a `Hello World!` function that can greet someone given their name.  The
-function should return the appropriate greeting.
-
-For an input of "Alice", the response should be "Hello, Alice!".
-
-If a name is not given, the response should be "Hello, World!"
-
-## Test-Driven Development
-
-As programmers mature, they eventually want to test their code.
-
-Here at Exercism we simulate [Test-Driven
-Development](http://en.wikipedia.org/wiki/Test-driven_development) (TDD), where
-you write your tests before writing any functionality. The simulation comes in
-the form of a pre-written test suite, which will signal that you have solved
-the problem.
-
-It will also provide you with a safety net to explore other solutions without
-breaking the functionality.
-
-### A typical TDD workflow on Exercism:
-
-1. Run the test file and pick one test that's failing.
-2. Write some code to fix the test you picked.
-3. Re-run the tests to confirm the test is now passing.
-4. Repeat from step 1.
-5. Submit your solution (`exercism submit /path/to/file`)
-
-## Instructions
-
-Submissions are encouraged to be general, within reason. Having said that, it's
-also important not to over-engineer a solution.
-
-It's important to remember that the goal is to make code as expressive and
-readable as we can. However, solutions to the hello-world exercise will not be
-reviewed by a person, but by rikki- the robot, who will offer an encouraging
-word.
+If everything goes well, you will be ready to fetch your first real exercise.

--- a/exercises/hello-world/metadata.yml
+++ b/exercises/hello-world/metadata.yml
@@ -1,4 +1,4 @@
 ---
-blurb: 'Greet the user by name, or by saying "Hello, World!" if no name is given.'
+blurb: 'The classical introductory exercise. Just say "Hello, World!"'
 source: "This is an exercise to introduce users to using Exercism"
 source_url: "http://en.wikipedia.org/wiki/%22Hello,_world!%22_program"


### PR DESCRIPTION
As discussed in #520, the exercise `hello-world` is too complex to fulfill its purpose and we decided to simplify it.

The new test suite will simply expect the string **"Hello, World!"**, and will serve mainly as a sanity check that everything is working.

This change may disrupt some tracks that already have it implemented, so we are scheduling the merging of this PR to allow the @exercism/track-maintainers to sync track-specific changes with `x-common`.

The merging is tentatively scheduled to: **2016-02-20 00:01 UTC** +-1 day 😄

Please direct any question/critic to #520, so that we can keep the discussion focused there.

Closes #520.