### PR TITLE
book store: Explain importance of greediness vs non-greediness

### DIFF
--- a/exercises/book-store/canonical-data.json
+++ b/exercises/book-store/canonical-data.json
@@ -52,7 +52,7 @@
            "expected": 30.00
          },
          {
-           "description": "Two each of first 3 books and 1 copy each of rest",
+           "description": "Two groups of four is cheaper than group of five plus group of three",
            "basket": [1,1,2,2,3,3,4,5],
            "targetgrouping": [[1,2,3,4],[1,2,3,5]],
            "expected": 51.20

--- a/exercises/book-store/canonical-data.json
+++ b/exercises/book-store/canonical-data.json
@@ -58,6 +58,12 @@
            "expected": 51.20
          },
          {
+           "description": "Group of four plus group of two is cheaper than two groups of three",
+           "basket": [1,1,2,2,3,4],
+           "targetgrouping": [[1,2,3,4],[1,2]],
+           "expected": 40.8
+         },
+         {
            "description": "Two each of first 4 books and 1 copy each of rest",
            "basket": [1,1,2,2,3,3,4,4,5],
            "targetgrouping": [[1,2,3,4,5],[1,2,3,4]],


### PR DESCRIPTION
It is important to us that descriptions explain **why** a case is being tested.

To this end, I explain in the description why the 11223345 case is being tested: Because you cannot greedily add books to a single group in this case. You have to know that two groups of four is cheaper than five plus three.

If this is not made clear, people may make assumptions that greedy is the correct way to go, as in: https://github.com/exercism/xcsharp/issues/181

To contrast this, immediately after I add a case where you should greedily add books to a single group: 4 + 2 is cheaper than 3 + 3.

I do not have in mind right now a better description for any other case in this file.