### PR TITLE
Add JSON Schema for 'canonical-data.json' and update the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,21 +36,76 @@ There are three metadata files:
 ## Test Data Format (canonical-data.json)
 
 This data can be incorporated into test programs manually or extracted by a
-program.  The file contains a single JSON object with a key for documentation
-and keys for various tests that may be meaningful for a problem.
+program.  The file format is described in `canonical-schema.json`, but it
+is easier to understand with a example:
 
-The documentation uses the key "#" with a list of strings as the value.
-These strings document how the problem readme (`description.md`) is generally
-interpreted in test programs across different languages.  In addition to a
-mainstream implementation path, this information can also document significant
-variations.
+```json
+{ "exercise": "foobar"
+, "version" : "1.0.0"
+, "comments":
+    [ " Comments are always optional and can be used almost anywhere.      "
+    , "                                                                    "
+    , " They usually document how the exercise's readme ('description.md') "
+    , " is generally interpreted in test programs across different         "
+    , " languages.                                                         "
+    , "                                                                    "
+    , " In addition to a mainstream implementation path, this information  "
+    , " can also document significant variations.                          "
+    ]
+, "cases":
+    [ { "comments":
+          [ " A test case must have a 'description' and a 'property'.  "
+          , " Anything else is optional.                               "
+          , "                                                          "
+          , " The 'property' is a string in lowerCamelCase identifying "
+          , " the type of test, but most of the times it is just the   "
+          , " name of a function being tested.                         "
+          , "                                                          "
+          , " Test cases can have any number of additional keys, and   "
+          , " most of them also have an 'expected' one, defining the   "
+          , " value a test should return.                              "
+          ]
+      , "description": "Foo'ing a word returns it reversed"
+      , "property"   : "foo"
+      , "input"      : "lion"
+      , "expected"   : "noil"
+      }
+    , { "description": "Bar'ing a name returns its parts combined"
+      , "property"   : "bar"
+      , "firstName"  : "Alan"
+      , "lastName"   : "Smithee"
+      , "expected"   : "ASlmainthee"
+      }
+    , { "comments":
+          [ " Test cases can be arbitrarily grouped with a description "
+          , " to make organization easier.                             "
+          ]
+      , "description": "Abnormal inputs: numbers"
+      , "cases":
+          [ { "description": "Foo'ing a number returns nothing"
+            , "property"   : "foo"
+            , "input"      : "42"
+            , "expected"   : null
+            }
+          , { "description": "Bar'ing a name with numbers gives an error"
+            , "property"   : "bar"
+            , "firstName"  : "HAL"
+            , "lastName"   : "9000"
+            , "expected"   : { "error": "You should never bar a number" }
+            }
+          ]
+      }
+  ]
+}
 
-Each test case has the the following keys:
-- description: which will be used to name each generated test
-  - The description should not simply explain **what** each case is (that is redundant information)
-  - The description should explain **why** each case is there. For example, what kinds of implementation mistakes might this case help us find?
-- 'variable names': one or more variable names with values which will be passed to the solution method
-- expected: the expected result
+```
+
+Keep in mind that the description should not simply explain **what** each case
+is (that is redundant information) but also **why** each case is there. For
+example, what kinds of implementation mistakes might this case help us find?
+
+There are also some convention about `expected` that you must follow:
+
   - if the input is valid but there is no result for the input, the value at `"expected"` should be `null`.
   - if an error is expected (because the input is invalid, or any other reason), the value at `"expected"` should be an object containing exactly one property, `"error"`, whose value is a string.
     - The string should explain why the error would occur.

--- a/canonical-schema.json
+++ b/canonical-schema.json
@@ -1,0 +1,137 @@
+{
+   "comments":
+   [ " This is a JSON Schema for 'canonical-data.json' files.     "
+   , "                                                            "
+   , " It enforces just a general structure for all exercises,    "
+   , " without specifying how the test data should be organized   "
+   , " for each type of test. We do this to keep generality and   "
+   , " allow support for tests the do not fit well in the         "
+   , " 'function (input) == output' structure, like property      "
+   , " tests.                                                     "
+   , "                                                            "
+   , " The only thing enforced regarding how test data should be  "
+   , " structured is the error encoding, because it was agreed    "
+   , " and it doesn't restrict flexibility in a significant way.  "
+   , "                                                            "
+   , " Standardized property names may help when automatically    "
+   , " deriving JSON parsers in some languages, so we followed    "
+   , " a few conventions from the 'Google JSON Style Guide'.      "
+   , "                                                            "
+   , " Additionally, this schema strictly enforces letters, in    "
+   , " lowerCamelCase, for naming the 'property' being tested. We "
+   , " expect this regularity will allow an easier automatic      "
+   , " generation of function's names in test generators,         "
+   , " slightly reducing the amount of manually generated code.   "
+   ],
+
+   "$schema": "http://json-schema.org/draft-04/schema#",
+
+   "self": { "vendor" : "io.exercism"
+           , "name"   : "canonical-data"
+           , "format" : "jsonschema"
+           , "version": "1-0-0"
+           },
+
+   "$ref": "#/definitions/canonicalData",
+
+   "definitions":{
+
+      "canonicalData":
+          { "description": "This is the top-level file structure"
+          , "type"       : "object"
+          , "required"   : ["exercise" , "version", "cases"]
+          , "properties" :
+                { "exercise" : { "$ref": "#/definitions/exercise"  }
+                , "version"  : { "$ref": "#/definitions/version"   }
+                , "comments" : { "$ref": "#/definitions/comments"  }
+                , "cases"    : { "$ref": "#/definitions/testGroup" }
+                }
+          , "additionalProperties": false
+          },
+
+      "exercise":
+          { "description": "Exercise's slug (kebab-case)"
+          , "type"       : "string"
+          , "pattern"    : "^[a-z]+(-[a-z]+)*$"
+          },
+
+      "version" :
+          { "description" : "Semantic versioning: MAJOR.MINOR.PATCH"
+          , "type"        : "string"
+          , "pattern"     : "^(0|[1-9][0-9]*)(\\.(0|[1-9][0-9]*)){2}$"
+          },
+
+      "comments":
+          { "description": "An array of strings to fake multi-line comments"
+          , "type"       : "array"
+          , "items"      : { "type": "string" }
+          , "minItems"   : 1
+          },
+
+      "testGroup":
+          { "description": "An array of labeled test items"
+          , "type"       : "array"
+          , "items"      : { "$ref": "#/definitions/labeledTestItem" }
+          , "minItems"   : 1
+          },
+
+      "labeledTestItem":
+          { "description": "A single test or group of tests with a description"
+          , "oneOf": [ { "$ref": "#/definitions/labeledTest"      }
+                     , { "$ref": "#/definitions/labeledTestGroup" }
+                     ]
+          },
+
+      "labeledTest":
+          { "description": "A single test with a description"
+          , "type"       : "object"
+          , "required"   : ["description", "property"]
+          , "properties" :
+                { "description": { "$ref": "#/definitions/description" }
+                , "comments"   : { "$ref": "#/definitions/comments"    }
+                , "property"   : { "$ref": "#/definitions/property"    }
+                , "expected"   : { "$ref": "#/definitions/expected"    }
+                }
+          },
+
+      "labeledTestGroup":
+          { "description": "A group of tests with a description"
+          , "type"       : "object"
+          , "required"   : ["description", "cases"]
+          , "properties" :
+                { "description": { "$ref": "#/definitions/description" }
+                , "comments"   : { "$ref": "#/definitions/comments"    }
+                , "cases"      : { "$ref": "#/definitions/testGroup"   }
+                }
+          , "additionalProperties": false
+          },
+
+      "description":
+          { "description": "A short, clear, one-line description"
+          , "type"       : "string"
+          },
+
+      "property":
+          { "description": "A letters-only, lowerCamelCase property name"
+          , "type"       : "string"
+          , "pattern"    : "^[a-z]+([A-Z][a-z]+)*[A-Z]?$"
+          },
+
+      "expected":
+          { "description": "The expected return value of a test case"
+          , "properties":
+               { "error": { "$ref": "#/definitions/error" }
+               }
+          , "dependencies":
+               { "error": { "maxProperties": 1 }
+               }
+          },
+
+      "error":
+          { "description": "A message describing an error condition"
+          , "type"       : "string"
+          }
+
+    }
+
+}


### PR DESCRIPTION
In exercism/x-common#336 (`canonical-data.json` standardisation discussion), it was recently discussed a JSON Schema to capture the fundamental structure needed for `canonical-data.json` files.

After a lot of discussions and a few iterations, the [resulting schema](https://github.com/exercism/x-common/issues/336#issuecomment-280550277) proposed seems stable and mature enough to become at least a recommended standard, IMHO.

This proposal was designed with the following goals:

- Keep/improve human-readability.
- Keep it flexible enough to allow designing any reasonable test suite.
- Make it more regular and machine-readable.

There where naturally some trade-offs, as it is impossible to satisfy these objectives completely, but I think we got a good balance here.

To get a first impression of what is this about, in this new schema, a simple test suite would look like this:

```json
{ "exercise": "foobar"
, "version" : "1.0.0"
, "cases":
    [ { "description": "Foo'ing a word returns it reversed"
      , "property"   : "foo"
      , "input"      : "lion"
      , "expected"   : "noil"
      }
    , { "description": "Bar'ing a name returns its parts combined"
      , "property"   : "bar"
      , "firstName"  : "Alan"
      , "lastName"   : "Smithee"
      , "expected"   : "ASlmainthee"
      }
    ]
}
```

Of course,  there are more features, like comments, test groups and error signaling!

We expect that this change will soon allow us to:

- Automatically verify the `canonical-data.json` files.
- Simplify test generation, allowing more code to be shared among all exercises.
- Pave the way for future standardization. As our understanding of test suite design improves and new best practices emerge, it will be easy to patch this schema to capture even more structure.

We know that this proposal will not make it possible to generate a test suite in a fully automatic way. To allow that we would have to significantly change all the test suites, and [there was no agreement](https://github.com/exercism/x-common/issues/336#issuecomment-262184838) about how to do it or even if that is desirable.

Considering that this is a very sensible and highly debated topic, we shouldn't merge this PR until we are sure that enough people have a clear understanding of it and think this is an improvement over what we currently have.

We would like to know what do you think about this proposal. So, after studying it for a while, please...

- Say ❤️ if you think this is great!
- Say 👍 if you think this would make `x-common` better.
- Say 👎  if you think this would make `x-common` worse.
- If you have any question about it, please ask!

Also, if you think this isn't good the way it is, please consider helping us improve it!

Closes #336.