### PR TITLE
metadata.yml: Remove nonstandard metadata (cleanup)

### DIFF
--- a/exercises/counter/metadata.yml
+++ b/exercises/counter/metadata.yml
@@ -1,6 +1,2 @@
 ---
 blurb: "Design a test suite for a line/letter/character counter tool."
-common:
-    type: focus
-    special: reverse
-deprecated: true

--- a/exercises/error-handling/metadata.yml
+++ b/exercises/error-handling/metadata.yml
@@ -1,6 +1,2 @@
 ---
 blurb: "Implement various kinds of error handling and resource management"
-common:
-    type: focus
-go:
-    topics: ["defer", "errors", "panic"]

--- a/exercises/lens-person/metadata.yml
+++ b/exercises/lens-person/metadata.yml
@@ -1,5 +1,2 @@
 ---
 blurb: "Use lenses to update nested records (specific to languages with immutable data)."
-common:
-    type: focus
-    focus: lenses

--- a/exercises/nucleotide-codons/metadata.yml
+++ b/exercises/nucleotide-codons/metadata.yml
@@ -1,4 +1,2 @@
 ---
 blurb: "Write a function that returns the name of an amino acid a particular codon, possibly using shorthand, encodes for."
-common:
-    type: practice

--- a/exercises/react/metadata.yml
+++ b/exercises/react/metadata.yml
@@ -1,4 +1,2 @@
 ---
 blurb: "Implement a basic reactive system."
-type: practice
-topics: ["observers", "reactive programming"]

--- a/exercises/rectangles/metadata.yml
+++ b/exercises/rectangles/metadata.yml
@@ -1,5 +1,2 @@
 ---
 blurb: Count the rectangles in an ASCII diagram.
-common:
-    type: practice
-    focus: algorithms

--- a/exercises/variable-length-quantity/metadata.yml
+++ b/exercises/variable-length-quantity/metadata.yml
@@ -1,6 +1,4 @@
 ---
 blurb: "Implement variable length quantity encoding and decoding."
-type: practice
 source: "A poor Splice developer having to implement MIDI encoding/decoding."
 source_url: "https://splice.com"
-topics: ["encoding", "decoding", "MIDI"]


### PR DESCRIPTION
As discussed in exercism/x-common#597, it seems there is no reason to keep information about deprecation or exercise classification in the `metadata.yml` files.

Closes #597