### PR TITLE
perfect-numbers: add canonical data

### DIFF
--- a/exercises/perfect-numbers/canonical-data.json
+++ b/exercises/perfect-numbers/canonical-data.json
@@ -1,0 +1,108 @@
+{
+    "exercise": "perfect-numbers",
+    "version": "1.0.0",
+    "cases": [
+        {
+            "description": "Perfect numbers",
+            "cases": [
+                {
+                    "description": "Smallest perfect number is classified correctly",
+                    "property": "classify",
+                    "input": 6,
+                    "expected": "perfect"
+                },
+                {
+                    "description": "Medium perfect number is classified correctly",
+                    "property": "classify",
+                    "input": 28,
+                    "expected": "perfect"
+                },
+                {
+                    "description": "Large perfect number is classified correctly",
+                    "property": "classify",
+                    "input": 33550336,
+                    "expected": "perfect"
+                }
+            ]
+        },
+        {
+            "description": "Abundant numbers",
+            "cases": [
+                {
+                    "description": "Smallest abundant number is classified correctly",
+                    "property": "classify",
+                    "input": 12,
+                    "expected": "abundant"
+                },
+                {
+                    "description": "Medium abundant number is classified correctly",
+                    "property": "classify",
+                    "input": 30,
+                    "expected": "abundant"
+                },
+                {
+                    "description": "Large abundant number is classified correctly",
+                    "property": "classify",
+                    "input": 33550335,
+                    "expected": "abundant"
+                }
+            ]
+        },
+        {
+            "description": "Deficient numbers",
+            "cases": [
+                {
+                    "description": "Smallest prime deficient number is classified correctly",
+                    "property": "classify",
+                    "input": 2,
+                    "expected": "deficient"
+                },
+                {
+                    "description": "Smallest non-prime deficient number is classified correctly",
+                    "property": "classify",
+                    "input": 4,
+                    "expected": "deficient"
+                },
+                {
+                    "description": "Medium deficient number is classified correctly",
+                    "property": "classify",
+                    "input": 32,
+                    "expected": "deficient"
+                },
+                {
+                    "description": "Large deficient number is classified correctly",
+                    "property": "classify",
+                    "input": 33550337,
+                    "expected": "deficient"
+                },
+                {
+                    "description": "Edge case (no factors other than itself) is classified correctly",
+                    "property": "classify",
+                    "input": 1,
+                    "expected": "deficient"
+                }
+            ]
+        },
+        {
+            "description": "Invalid inputs",
+            "cases": [
+                {
+                    "description": "Non-negative integer is rejected (not a natural number)",
+                    "property": "classify",
+                    "input": 0,
+                    "expected": {
+                        "error": "Classification is only possible for natural numbers."
+                    }
+                },
+                {
+                    "description": "Negative integer is rejected (not a natural number)",
+                    "property": "classify",
+                    "input": -1,
+                    "expected": {
+                        "error": "Classification is only possible for natural numbers."
+                    }
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Closes #575. See that issue for background information. Please contribute any new comments in this PR. Thanks!

I attempted to follow the proposed canonical data spec from https://github.com/exercism/x-common/pull/602. If you spot any deviations from the proposal, please let me know and I can correct them. cc @rbasso for his expertise and validation 😄 [One thing I was unsure of: whether it is expected that inputs/outputs always be strings, or whether other data types (as used for inputs here) are permitted by that spec.]