### PR TITLE
Correct unimplemented exercises link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -290,10 +290,10 @@ here.
 ## Porting an Exercise to Another Language Track
 
 To get a list of all the exercises that can be ported to a track,
-go to the url `http://exercism.io/languages/:track_id/contribute`.
+go to the url `http://exercism.io/languages/:track_id/todo`.
 
 For example here is the list of exercises that have not yet been implemented
-for the Ruby track: http://exercism.io/languages/ruby/contribute
+for the Ruby track: http://exercism.io/languages/ruby/todo
 
 Each unimplemented exercise links to existing implementations of the exercise in
 other language tracks, so that people can use those example solutions and test


### PR DESCRIPTION
The description for the link says:
* to get a list of all the exercises that can be ported to a track
* for example here is the list of exercises that have not yet been implemented for the Ruby track

This clearly indicates that we want to go to the url which shows list of exercises that are present correctly at relative path _/todo_ not _/contribute_. In fact, _/contribute_ link redirects to _/todo_ link for the list of exercises still unimplemented.
So, we can avoid this always needed redirect for ease of use.