### PR TITLE
perfect-numbers: fix misleading test description

### DIFF
--- a/exercises/perfect-numbers/canonical-data.json
+++ b/exercises/perfect-numbers/canonical-data.json
@@ -1,6 +1,6 @@
 {
     "exercise": "perfect-numbers",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "cases": [
         {
             "description": "Perfect numbers",
@@ -87,7 +87,7 @@
             "description": "Invalid inputs",
             "cases": [
                 {
-                    "description": "Non-negative integer is rejected (not a natural number)",
+                    "description": "Zero is rejected (not a natural number)",
                     "property": "classify",
                     "input": 0,
                     "expected": {


### PR DESCRIPTION
Original description

> Non-negative integer is rejected (not a natural number)

could be interpreted as suggesting that _any_ non-negative integer should be rejected. This is not the case. New description

> Zero is rejected (not a natural number)

reflects intent much better.