### PR TITLE
rotational-cipher: match test data to description (26 -> 0)

### DIFF
--- a/exercises/rotational-cipher/canonical-data.json
+++ b/exercises/rotational-cipher/canonical-data.json
@@ -20,7 +20,7 @@
             {
                 "description": "rotate a by 0, same output as input",
                 "text": "a",
-                "shift_key": 26,
+                "shift_key": 0,
                 "expected": "a"
             },
             {


### PR DESCRIPTION
Should effectively be the same test as the one above it due to modulus
math, but was also literally the same test.