### PR TITLE
anagram: Rename duplicated test case description

### DIFF
--- a/exercises/anagram/canonical-data.json
+++ b/exercises/anagram/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "anagram",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "comments": [
     "The string argument cases possible matches are passed in as",
     "individual arguments rather than arrays. Languages can include",

--- a/exercises/anagram/canonical-data.json
+++ b/exercises/anagram/canonical-data.json
@@ -30,7 +30,7 @@
       "expected": []
     },
     {
-      "description": "detects multiple anagrams",
+      "description": "detects two anagrams",
       "property": "anagrams",
       "subject": "master",
       "candidates": ["stream", "pigeon", "maters"],
@@ -51,7 +51,7 @@
       "expected": ["inlets"]
     },
     {
-      "description": "detects multiple anagrams",
+      "description": "detects three anagrams",
       "property": "anagrams",
       "subject": "allergy",
       "candidates": [ "gallery",


### PR DESCRIPTION
There are some tracks that generate their test suits and use the description field as name for the test function/method.
If this would get merged. Do we change the version to 1.1.0 or 1.0.1?

*Note: Don't know if the new names are so great but I couldn't find different ones.*