### PR TITLE
custom-set: Fix description that doesn't match property name

### DIFF
--- a/exercises/custom-set/canonical-data.json
+++ b/exercises/custom-set/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "custom-set",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "comments": [
     "These tests cover the core components of a set data structure: checking",
     "presence, adding, comparing and basic set operations. Other features",
@@ -209,7 +209,7 @@
       ]
     },
     {
-      "description": "Intersect returns a set of all shared elements",
+      "description": "Intersection returns a set of all shared elements",
       "cases": [
         {
           "description": "intersection of two empty sets is an empty set",


### PR DESCRIPTION
~~**Warning:** This PR is based on #672, and should not be merged before it. Only the third commit is new.~~

As suggested in [this comment](https://github.com/exercism/x-common/pull/672#discussion_r105240340), this PR chances the a description in the canonical data, and so it also bumps the PATCH version number.