### PR TITLE
pov: Make exercise schema-compliant

### DIFF
--- a/exercises/pov/canonical-data.json
+++ b/exercises/pov/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "pov",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "cases": [{
     "description": "Reroot a tree so that its root is the specified node.",
     "comments": [
@@ -240,7 +240,28 @@
       {
         "description": "Errors if target does not exist in a large tree",
         "property": "fromPov",
-        "tree": "cousins",
+        "tree": {
+          "label": "parent",
+          "children": [
+            {
+              "label": "x",
+              "children": [
+                {
+                  "label": "kid-0"
+                },
+                {
+                  "label": "kid-1"
+                }
+              ]
+            },
+            {
+              "label": "sibling-0"
+            },
+            {
+              "label": "sibling-1"
+            }
+          ]
+        },
         "from": "nonexistent",
         "expected": null
       }
@@ -321,16 +342,29 @@
       {
         "description": "Can find path from nodes other than x",
         "property": "pathTo",
-        "from": "kid-1",
-        "to": "cousin-0",
-        "tree": "cousins",
+        "from": "a",
+        "to": "c",
+        "tree": {
+          "label": "parent",
+          "children": [
+            {
+              "label": "a"
+            },
+            {
+              "label": "x"
+            },
+            {
+              "label": "b"
+            },
+            {
+              "label": "c"
+            }
+          ]
+        },
         "expected": [
-          "kid-1",
-          "x",
+          "a",
           "parent",
-          "grandparent",
-          "uncle",
-          "cousin-0"
+          "c"
         ]
       },
       {
@@ -338,7 +372,28 @@
         "property": "pathTo",
         "from": "x",
         "to": "nonexistent",
-        "tree": "cousins",
+        "tree": {
+          "label": "parent",
+          "children": [
+            {
+              "label": "x",
+              "children": [
+                {
+                  "label": "kid-0"
+                },
+                {
+                  "label": "kid-1"
+                }
+              ]
+            },
+            {
+              "label": "sibling-0"
+            },
+            {
+              "label": "sibling-1"
+            }
+          ]
+        },
         "expected": null
       },
       {
@@ -346,7 +401,28 @@
         "property": "pathTo",
         "from": "nonexistent",
         "to": "x",
-        "tree": "cousins",
+        "tree": {
+          "label": "parent",
+          "children": [
+            {
+              "label": "x",
+              "children": [
+                {
+                  "label": "kid-0"
+                },
+                {
+                  "label": "kid-1"
+                }
+              ]
+            },
+            {
+              "label": "sibling-0"
+            },
+            {
+              "label": "sibling-1"
+            }
+          ]
+        },
         "expected": null
       }
     ]

--- a/exercises/pov/canonical-data.json
+++ b/exercises/pov/canonical-data.json
@@ -1,7 +1,9 @@
 {
-  "from_pov": {
-    "description": [
-      "Reroot a tree so that its root is the specified node.",
+  "exercise": "pov",
+  "version": "1.0.0",
+  "cases": [{
+    "description": "Reroot a tree so that its root is the specified node.",
+    "comments": [
       "In this way, the tree is presented from the point of view of the specified node.",
       "The input trees used here are those in the `trees` section of this file.",
       "",
@@ -17,6 +19,7 @@
     "cases": [
       {
         "description": "Results in the same tree if the input tree is a singleton",
+        "property": "fromPov",
         "tree": "singleton",
         "from": "x",
         "expected": {
@@ -25,6 +28,7 @@
       },
       {
         "description": "Can reroot a tree with a parent and one sibling",
+        "property": "fromPov",
         "tree": "simple",
         "from": "x",
         "expected": {
@@ -43,6 +47,7 @@
       },
       {
         "description": "Can reroot a tree with a parent and many siblings",
+        "property": "fromPov",
         "tree": "large_flat",
         "from": "x",
         "expected": {
@@ -67,6 +72,7 @@
       },
       {
         "description": "Can reroot a tree with new root deeply nested in tree",
+        "property": "fromPov",
         "tree": "deeply_nested",
         "from": "x",
         "expected": {
@@ -95,6 +101,7 @@
       },
       {
         "description": "Moves children of the new root to same level as former parent",
+        "property": "fromPov",
         "tree": "kids",
         "from": "x",
         "expected": {
@@ -114,6 +121,7 @@
       },
       {
         "description": "Can reroot a complex tree with cousins",
+        "property": "fromPov",
         "tree": "cousins",
         "from": "x",
         "expected": {
@@ -157,21 +165,22 @@
       },
       {
         "description": "Errors if target does not exist in a singleton tree",
+        "property": "fromPov",
         "tree": "singleton",
         "from": "nonexistent",
         "expected": null
       },
       {
         "description": "Errors if target does not exist in a large tree",
+        "property": "fromPov",
         "tree": "cousins",
         "from": "nonexistent",
         "expected": null
       }
     ]
-  },
-  "path_to": {
-    "description": [
-      "Given two nodes, find the path between them.",
+  }, {
+    "description": "Given two nodes, find the path between them",
+    "comments": [
       "A typical implementation would first reroot the tree on one of the two nodes.",
       "",
       "If appropriate for your track, you may test that the input tree is not modified.",
@@ -181,6 +190,7 @@
     "cases": [
       {
         "description": "Can find path to parent",
+        "property": "pathTo",
         "from": "x",
         "to": "parent",
         "tree": "simple",
@@ -191,6 +201,7 @@
       },
       {
         "description": "Can find path to sibling",
+        "property": "pathTo",
         "from": "x",
         "to": "b",
         "tree": "large_flat",
@@ -202,6 +213,7 @@
       },
       {
         "description": "Can find path to cousin",
+        "property": "pathTo",
         "from": "x",
         "to": "cousin-1",
         "tree": "cousins",
@@ -215,6 +227,7 @@
       },
       {
         "description": "Can find path from nodes other than x",
+        "property": "pathTo",
         "from": "kid-1",
         "to": "cousin-0",
         "tree": "cousins",
@@ -229,6 +242,7 @@
       },
       {
         "description": "Errors if destination does not exist",
+        "property": "pathTo",
         "from": "x",
         "to": "nonexistent",
         "tree": "cousins",
@@ -236,13 +250,14 @@
       },
       {
         "description": "Errors if source does not exist",
+        "property": "pathTo",
         "from": "nonexistent",
         "to": "x",
         "tree": "cousins",
         "expected": null
       }
     ]
-  },
+  }],
   "trees": {
     "singleton": {
       "label": "x"

--- a/exercises/pov/canonical-data.json
+++ b/exercises/pov/canonical-data.json
@@ -187,7 +187,44 @@
       {
         "description": "Can reroot a complex tree with cousins",
         "property": "fromPov",
-        "tree": "cousins",
+        "tree": {
+          "label": "grandparent",
+          "children": [
+            {
+              "label": "parent",
+              "children": [
+                {
+                  "label": "x",
+                  "children": [
+                    {
+                      "label": "kid-0"
+                    },
+                    {
+                      "label": "kid-1"
+                    }
+                  ]
+                },
+                {
+                  "label": "sibling-0"
+                },
+                {
+                  "label": "sibling-1"
+                }
+              ]
+            },
+            {
+              "label": "uncle",
+              "children": [
+                {
+                  "label": "cousin-0"
+                },
+                {
+                  "label": "cousin-1"
+                }
+              ]
+            }
+          ]
+        },
         "from": "x",
         "expected": {
           "label": "x",
@@ -330,7 +367,44 @@
         "property": "pathTo",
         "from": "x",
         "to": "cousin-1",
-        "tree": "cousins",
+        "tree": {
+          "label": "grandparent",
+          "children": [
+            {
+              "label": "parent",
+              "children": [
+                {
+                  "label": "x",
+                  "children": [
+                    {
+                      "label": "kid-0"
+                    },
+                    {
+                      "label": "kid-1"
+                    }
+                  ]
+                },
+                {
+                  "label": "sibling-0"
+                },
+                {
+                  "label": "sibling-1"
+                }
+              ]
+            },
+            {
+              "label": "uncle",
+              "children": [
+                {
+                  "label": "cousin-0"
+                },
+                {
+                  "label": "cousin-1"
+                }
+              ]
+            }
+          ]
+        },
         "expected": [
           "x",
           "parent",
@@ -426,45 +500,5 @@
         "expected": null
       }
     ]
-  }],
-  "trees": {
-    "cousins": {
-      "label": "grandparent",
-      "children": [
-        {
-          "label": "parent",
-          "children": [
-            {
-              "label": "x",
-              "children": [
-                {
-                  "label": "kid-0"
-                },
-                {
-                  "label": "kid-1"
-                }
-              ]
-            },
-            {
-              "label": "sibling-0"
-            },
-            {
-              "label": "sibling-1"
-            }
-          ]
-        },
-        {
-          "label": "uncle",
-          "children": [
-            {
-              "label": "cousin-0"
-            },
-            {
-              "label": "cousin-1"
-            }
-          ]
-        }
-      ]
-    }
-  }
+  }]
 }

--- a/exercises/pov/canonical-data.json
+++ b/exercises/pov/canonical-data.json
@@ -20,7 +20,9 @@
       {
         "description": "Results in the same tree if the input tree is a singleton",
         "property": "fromPov",
-        "tree": "singleton",
+        "tree": {
+          "label": "x"
+        },
         "from": "x",
         "expected": {
           "label": "x"
@@ -29,7 +31,17 @@
       {
         "description": "Can reroot a tree with a parent and one sibling",
         "property": "fromPov",
-        "tree": "simple",
+        "tree": {
+          "label": "parent",
+          "children": [
+            {
+              "label": "x"
+            },
+            {
+              "label": "sibling"
+            }
+          ]
+        },
         "from": "x",
         "expected": {
           "label": "x",
@@ -48,7 +60,23 @@
       {
         "description": "Can reroot a tree with a parent and many siblings",
         "property": "fromPov",
-        "tree": "large_flat",
+        "tree": {
+          "label": "parent",
+          "children": [
+            {
+              "label": "a"
+            },
+            {
+              "label": "x"
+            },
+            {
+              "label": "b"
+            },
+            {
+              "label": "c"
+            }
+          ]
+        },
         "from": "x",
         "expected": {
           "label": "x",
@@ -73,7 +101,29 @@
       {
         "description": "Can reroot a tree with new root deeply nested in tree",
         "property": "fromPov",
-        "tree": "deeply_nested",
+        "tree": {
+          "label": "level-0",
+          "children": [
+            {
+              "label": "level-1",
+              "children": [
+                {
+                  "label": "level-2",
+                  "children": [
+                    {
+                      "label": "level-3",
+                      "children": [
+                        {
+                          "label": "x"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
         "from": "x",
         "expected": {
           "label": "x",
@@ -102,7 +152,22 @@
       {
         "description": "Moves children of the new root to same level as former parent",
         "property": "fromPov",
-        "tree": "kids",
+        "tree": {
+          "label": "parent",
+          "children": [
+            {
+              "label": "x",
+              "children": [
+                {
+                  "label": "kid-0"
+                },
+                {
+                  "label": "kid-1"
+                }
+              ]
+            }
+          ]
+        },
         "from": "x",
         "expected": {
           "label": "x",
@@ -166,7 +231,9 @@
       {
         "description": "Errors if target does not exist in a singleton tree",
         "property": "fromPov",
-        "tree": "singleton",
+        "tree": {
+          "label": "x"
+        },
         "from": "nonexistent",
         "expected": null
       },
@@ -193,7 +260,17 @@
         "property": "pathTo",
         "from": "x",
         "to": "parent",
-        "tree": "simple",
+        "tree": {
+          "label": "parent",
+          "children": [
+            {
+              "label": "x"
+            },
+            {
+              "label": "sibling"
+            }
+          ]
+        },
         "expected": [
           "x",
           "parent"
@@ -204,7 +281,23 @@
         "property": "pathTo",
         "from": "x",
         "to": "b",
-        "tree": "large_flat",
+        "tree": {
+          "label": "parent",
+          "children": [
+            {
+              "label": "a"
+            },
+            {
+              "label": "x"
+            },
+            {
+              "label": "b"
+            },
+            {
+              "label": "c"
+            }
+          ]
+        },
         "expected": [
           "x",
           "parent",
@@ -259,76 +352,6 @@
     ]
   }],
   "trees": {
-    "singleton": {
-      "label": "x"
-    },
-    "simple": {
-      "label": "parent",
-      "children": [
-        {
-          "label": "x"
-        },
-        {
-          "label": "sibling"
-        }
-      ]
-    },
-    "large_flat": {
-      "label": "parent",
-      "children": [
-        {
-          "label": "a"
-        },
-        {
-          "label": "x"
-        },
-        {
-          "label": "b"
-        },
-        {
-          "label": "c"
-        }
-      ]
-    },
-    "deeply_nested": {
-      "label": "level-0",
-      "children": [
-        {
-          "label": "level-1",
-          "children": [
-            {
-              "label": "level-2",
-              "children": [
-                {
-                  "label": "level-3",
-                  "children": [
-                    {
-                      "label": "x"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    "kids": {
-      "label": "parent",
-      "children": [
-        {
-          "label": "x",
-          "children": [
-            {
-              "label": "kid-0"
-            },
-            {
-              "label": "kid-1"
-            }
-          ]
-        }
-      ]
-    },
     "cousins": {
       "label": "grandparent",
       "children": [


### PR DESCRIPTION
You probably want to review commit-by-commit (but hey don't let me tell you what to do, if you want to review the whole thing at once you are free to do it!).

I suppose there can still be a reformatting too (you'll notice a `"cases": [{`) line but...

1. Since `testGroup` is necessarily and both types that might be elements of it are objects, I have absolutely no compunction about putting the `[{` on the same line!
    * Unfortunately, I did not apply the same treatment to the inner `cases`, sorry.
2. Keeping that diff small!
3. Okay, if you *really* want me to reformat, I can, but I wanted to make sure that there are no *other* changes that people want, because then I would have to rebase and blow away my reformatting.