### PR TITLE
roman-numerals: add descriptions

### DIFF
--- a/exercises/roman-numerals/canonical-data.json
+++ b/exercises/roman-numerals/canonical-data.json
@@ -1,74 +1,92 @@
 {
    "cases": [
       {
+         "description": "1 is a single I",
          "number" : 1, 
          "expected": "I"
       },
       {
+         "description": "2 is two I's",
          "number" : 2, 
          "expected": "II"
       },
       {
+         "description": "3 is three I's",
          "number" : 3, 
          "expected": "III"
       },
       {
+         "description": "4, being 5 - 1, is IV",
          "number" : 4, 
          "expected": "IV"
       },
       {
+         "description": "5 is a single V",
          "number" : 5, 
          "expected": "V"
       },
       {
+         "description": "6, being 5 + 1, is VI",
          "number" : 6, 
          "expected": "VI"
       },
       {
+         "description": "9, being 10 - 1, is IX",
          "number" : 9, 
          "expected": "IX"
       },
       {
+         "description": "20 is two X's",
          "number" : 27, 
          "expected": "XXVII"
       },
       {
+         "description": "48 is not 50 - 2 but rather 40 + 8",
          "number" : 48, 
          "expected": "XLVIII"
       },
       {
+         "description": "50 is a single L",
          "number" : 59, 
          "expected": "LIX"
       },
       {
+         "description": "90, being 100 - 10, is XC",
          "number" : 93, 
          "expected": "XCIII"
       },
       {
+         "description": "100 is a single C",
          "number" : 141, 
          "expected": "CXLI"
       },
       {
+         "description": "60, being 50 + 10, is LX",
          "number" : 163, 
          "expected": "CLXIII"
       },
       {
+         "description": "400, being 500 - 100, is CD",
          "number" : 402, 
          "expected": "CDII"
       },
       {
+         "description": "500 is a single D",
          "number" : 575, 
          "expected": "DLXXV"
       },
       {
+         "description": "900, being 1000 - 100, is CM",
          "number" : 911, 
          "expected": "CMXI"
       },
       {
+         "description": "1000 is a single M",
          "number" : 1024, 
          "expected": "MXXIV"
       },
       {
+         "description": "3000 is three M's",
          "number" : 3000, 
          "expected": "MMM"
       }


### PR DESCRIPTION
We'd like some descriptions so that roman-numerals can be brought into
compliance with the schema, as in #625.

Closes #451 via replacement