### PR TITLE
two-bucket: Fix exercise name in canonical data

### DIFF
--- a/exercises/two-bucket/canonical-data.json
+++ b/exercises/two-bucket/canonical-data.json
@@ -1,6 +1,6 @@
 {
-  "exercise": "two-buckets",
-  "version": "1.0.0",
+  "exercise": "two-bucket",
+  "version": "1.0.1",
   "cases": [
     {
       "description": "(3, 5) -> 1, starting with the first bucket",


### PR DESCRIPTION
Fix a [silly mistake](https://github.com/exercism/x-common/pull/713#pullrequestreview-26441727) from #713.