### PR TITLE
phone-number: Clears up contradiction re: why 11 digits is invalid

### DIFF
--- a/exercises/phone-number/canonical-data.json
+++ b/exercises/phone-number/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "phone-number",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "cases": [
     {
       "description": "Cleanup user-entered phone numbers",
@@ -35,7 +35,7 @@
           "expected": null
         },
         {
-          "description": "invalid when 11 digits",
+          "description": "invalid when 11 digits does not start with a 1",
           "property": "clean",
           "phrase": "21234567890",
           "expected": null


### PR DESCRIPTION
There are two tests concerning 11 digit numbers.  One test says they are valid when the digits start with one.  The other test states that 11 digits is invalid, but doesn't state why.  The two tests seem to be contradicting each other.