### PR TITLE
Simple Cipher: Fix Broken Image

### DIFF
--- a/exercises/simple-cipher/description.md
+++ b/exercises/simple-cipher/description.md
@@ -19,7 +19,9 @@ being a couple letters off was sufficient so that people couldn't
 recognize the few words that they did know.
 
 Your task is to create a simple shift cipher like the Caesar Cipher.
-This image is a great example of the Caesar Cipher: ![Caesar Cipher][1]
+This image is a great example of the Caesar Cipher:
+
+![Caesar Cipher][1]
 
 For example:
 
@@ -74,5 +76,5 @@ If you want to go farther in this field, the questions begin to be about
 how we can exchange keys in a secure way. Take a look at [Diffie-Hellman
 on Wikipedia][dh] for one of the first implementations of this scheme.
 
-[1]: http://upload.wikimedia.org/wikipedia/en/7/75/Caesar3.png
+[1]: https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Caesar_cipher_left_shift_of_3.svg/320px-Caesar_cipher_left_shift_of_3.svg.png
 [dh]: http://en.wikipedia.org/wiki/Diffie%E2%80%93Hellman_key_exchange


### PR DESCRIPTION
The example image for the [Simple Cipher][1] exercise is currently broken.
This PR replaces this broken link with a working one from [Caesar Cipher][2] Wikipedia page.


[1]: http://exercism.io/exercises/haskell/simple-cipher/readme
[2]: https://en.wikipedia.org/wiki/Caesar_cipher