### PR TITLE
Simplify triangle description.

### DIFF
--- a/exercises/triangle/description.md
+++ b/exercises/triangle/description.md
@@ -1,28 +1,17 @@
-The program should raise an error if the triangle cannot exist.
+An _equilateral_ triangle has all three sides the same length.<br/>
+An _isoceles_ triangle has at least two sides the same length. (It is sometimes
+specified as having exactly two sides the same length, but for the purposes of
+this exercise we'll say at least two.)<br/>
+A _scalene_ triangle has all sides of different lengths.
 
-## Hint
+## Note
 
-The triangle inequality theorem states:
-z ≤ x + y
-where x,y, and z are the lengths of the sides of a triangle. In other words, the
-sum of the lengths of any two sides of a triangle always exceeds or is equal to
-the length of the third side.
-
-A corollary to the triangle inequality theorem is there are two classes of
-triangles--degenerate and non-degenerate. If the sum of the lengths of any two
-sides of a triangle is greater than the length of the third side, that triangle
-is two dimensional, has area, and belongs to the non-degenerate class. In
-mathematics, a degenerate case is a limiting case in which an element of a class
-of objects is qualitatively different from the rest of the class and hence
-belongs to another, usually simpler, class. The degenerate case of the triangle
-inequality theorem is when the sum of the lengths of any two sides of a triangle
-is equal to the length of the third side. A triangle with such qualities is
-qualitatively different from all the triangles in the non-degenerate class since
-it is one dimensional, looks like a straight line, and has no area. Such
-triangles are called degenerate triangles and they belong to the degenerate
-class.
+For a shape to be a triangle at all, all sides have to be of length > 0, and 
+the sum of the lengths of any two sides must be greater than or equal to the 
+length of the third side. See [Triangle Inequality](https://en.wikipedia.org/wiki/Triangle_inequality).
 
 ## Dig Deeper
 
-This exercise does not test for degenerate triangles. Feel free to add your own
-tests to check for degenerate triangles.
+The case where the sum of the lengths of two sides _equals_ that of the 
+third is known as a _degenerate_ triangle - it has zero area and looks like 
+a single line. Feel free to add your own code/tests to check for degenerate triangles.


### PR DESCRIPTION
I thought the description for triangle was a little wordy, so I shortened it.
Happy to revert on this if anyone thinks the text is not an improvement, but the line at the top:
> The program should raise an error if the triangle cannot exist.

should be changed, as not all languages would idiomatically raise errors in this case.