### PR TITLE
isogram: Add test for input not starting with duplicate letter

### DIFF
--- a/exercises/isogram/canonical-data.json
+++ b/exercises/isogram/canonical-data.json
@@ -58,6 +58,12 @@
           "property": "isIsogram",
           "input": "Emily Jung Schwartzkopf",
           "expected": true
+        },
+        {
+          "description": "non isogram with duplicated letter not at the start",
+          "property": "isIsogram",
+          "input": "supercalifragi",
+          "expected": false
         }
       ]
     }


### PR DESCRIPTION
This catches implementations that only check whether the very first
letter of the input is found more than once. Actual example:

    for char in input:
        return (False if input.count(char) > 1 else True)