### PR TITLE
Cleanup canonical-data for clock

### DIFF
--- a/exercises/clock/canonical-data.json
+++ b/exercises/clock/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "clock",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "comments": [
     "Most languages require constructing a clock with initial values,",
     "adding a positive or negative number of minutes, and testing equality",
@@ -10,7 +10,7 @@
   ],
   "cases": [
     {
-      "description": "Test creating a new clock with an initial time.",
+      "description": "Create a new clock with an initial time",
       "cases": [
         {
           "description": "on the hour",
@@ -148,7 +148,7 @@
       ]
     },
     {
-      "description": "Test adding and subtracting minutes.",
+      "description": "Add minutes",
       "cases": [
         {
           "description": "add minutes",
@@ -213,7 +213,12 @@
           "minute": 1,
           "add": 3500,
           "expected": "11:21"
-        },
+        }
+      ]
+    },
+    {
+      "description": "Subtract minutes",
+      "cases": [
         {
           "description": "subtract minutes",
           "property": "add",
@@ -281,7 +286,7 @@
       ]
     },
     {
-      "description": "Construct two separate clocks, set times, test if they are equal.",
+      "description": "Compare two clocks for equality",
       "cases": [
         {
           "description": "clocks with same time",


### PR DESCRIPTION
This PR does a cleanup of the canonical data of the `clock` exercise. It contains the following changes:

1. The word "Test" is removed from the test group descriptions, as that is superfluous (it is a test group description after all)
1. I've split the add and subtract test into separate groups. This makes things more sensible for test data generators.

I've bumped the PATCH version number, as I believe that according to the README, this qualifies as a patch version bump.