### PR TITLE
Pangram: Add the non-ascii test cases

### DIFF
--- a/exercises/pangram/canonical-data.json
+++ b/exercises/pangram/canonical-data.json
@@ -64,6 +64,18 @@
           "property": "isPangram",
           "input": "the quick brown fox jumped over the lazy FOX",
           "expected": false
+        },
+        {
+          "description":"pangram with non ascii characters",
+          "property": "isPangram",
+          "input": "Victor jagt zwölf Boxkämpfer quer über den großen Sylter Deich.",
+          "expected": true
+        },
+        {
+          "description":"pangram with non ascii characters missing character 'x'",
+          "property": "isPangram",
+          "input": "Victor jagt zwölf Botkämpfer quer über den großen Sylter Deich.",
+          "expected": false
         }
       ]
     }


### PR DESCRIPTION
These are the canonical data changes for additional pangram tests I originally wanted to add to the xscala repo (https://github.com/exercism/xscala/pull/348)

The first non-ascii test already exists in the xscala repo (so this would only sync it up to common), while I wanted to add the second one as well:
> I feel that another useful test would be a string with non-ascii characters, but with a missing character 'x'. This would invalidate solutions that are written to simply pass the previous test (e.g. by making the test for distinct characters be >= 26)

I am not sure if this would make sense for all languages, and what steps would be required to generate the per-language test cases.

Cheers!