### PR TITLE
Fix missing closing paren in protein-translation

### DIFF
--- a/exercises/protein-translation/description.md
+++ b/exercises/protein-translation/description.md
@@ -1,4 +1,4 @@
-Let's translate RNA sequences into proteins. [general ref](http://en.wikipedia.org/wiki/Translation_(biology)
+Let's translate RNA sequences into proteins. [general ref](http://en.wikipedia.org/wiki/Translation_(biology))
 
 RNA can be broken into three nucleotide sequences called codons, and then translated to a polypeptide like so:
 


### PR DESCRIPTION
The URL link to wikipedia was missing a closing parentheses. This caused the link to incorrectly render.