### PR TITLE
Add negative isogram case where word starts with a unique letter

### DIFF
--- a/exercises/isogram/canonical-data.json
+++ b/exercises/isogram/canonical-data.json
@@ -3,7 +3,7 @@
   "comments": [
     "An isogram is a word or phrase without a repeating letter."
   ],
-  "version": "1.0.0",
+  "version": "1.1.0",
   "cases": [
     {
       "description": "Check if the given string is an isogram",
@@ -58,6 +58,12 @@
           "property": "isIsogram",
           "input": "Emily Jung Schwartzkopf",
           "expected": true
+        },
+        {
+          "description": "duplicated character in the middle",
+          "property": "isIsogram",
+          "input": "accentor",
+          "expected": false
         }
       ]
     }


### PR DESCRIPTION
I used this exercise in an entry-level Python course and a participant
came up with the following attempt:

    def is_isogram(s):
      if s == '':
        return True
      t = s.lower()
      for c in t:
        if t.count(c) > 1:
          return False
        else:
          return True

Note how the loop is unconditionally aborted after the first iteration.
However, all the test cases of the existing test suite run green with
this wrong solution.

The added test case fixes this, i.e. the above fails and the example
solution still succeeds.