### PR TITLE
 flatten-array: Add test case for no nesting

### DIFF
--- a/exercises/flatten-array/canonical-data.json
+++ b/exercises/flatten-array/canonical-data.json
@@ -1,7 +1,13 @@
 {
   "exercise": "flatten-array",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "cases": [
+    {
+      "description": "no nesting",
+      "property": "flatten",
+      "input": [0, 1, 2],
+      "expected": [0, 1, 2]
+    },
     {
       "description": "flattens array with just integers present",
       "property": "flatten",


### PR DESCRIPTION
I think it's always good to have test cases for the scenario where nothing needs to be done.

Like the empty string test case in other exercises, this new test case checks that a list without nested lists stays untouched.