### PR TITLE
phone-number: Rewrite description and add tests

### DIFF
--- a/exercises/phone-number/canonical-data.json
+++ b/exercises/phone-number/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "phone-number",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "cases": [
     {
       "description": "Cleanup user-entered phone numbers",
@@ -13,20 +13,20 @@
         {
           "description": "cleans the number",
           "property": "clean",
-          "phrase": "(123) 456-7890",
-          "expected": "1234567890"
+          "phrase": "(223) 456-7890",
+          "expected": "2234567890"
         },
         {
           "description": "cleans numbers with dots",
           "property": "clean",
-          "phrase": "123.456.7890",
-          "expected": "1234567890"
+          "phrase": "223.456.7890",
+          "expected": "2234567890"
         },
         {
           "description": "cleans numbers with multiple spaces",
           "property": "clean",
-          "phrase": "123 456   7890   ",
-          "expected": "1234567890"
+          "phrase": "223 456   7890   ",
+          "expected": "2234567890"
         },
         {
           "description": "invalid when 9 digits",
@@ -37,14 +37,20 @@
         {
           "description": "invalid when 11 digits does not start with a 1",
           "property": "clean",
-          "phrase": "21234567890",
+          "phrase": "22234567890",
           "expected": null
         },
         {
           "description": "valid when 11 digits and starting with 1",
           "property": "clean",
-          "phrase": "11234567890",
-          "expected": "1234567890"
+          "phrase": "12234567890",
+          "expected": "2234567890"
+        },
+        {
+          "description": "valid when 11 digits and starting with 1 even with punctuation",
+          "property": "clean",
+          "phrase": "+1 (223) 456-7890",
+          "expected": "2234567890"
         },
         {
           "description": "invalid when more than 11 digits",
@@ -68,6 +74,18 @@
           "description": "invalid with right number of digits but letters mixed in",
           "property": "clean",
           "phrase": "1a2b3c4d5e6f7g8h9i0j",
+          "expected": null
+        },
+        {
+          "description": "invalid if area code does not start with 2-9",
+          "property": "clean",
+          "phrase": "(123) 456-7890",
+          "expected": null
+        },
+        {
+          "description": "invalid if exchange code does not start with 2-9",
+          "property": "clean",
+          "phrase": "(223) 056-7890",
           "expected": null
         }
       ]

--- a/exercises/phone-number/description.md
+++ b/exercises/phone-number/description.md
@@ -1,16 +1,22 @@
-The rules are as follows:
+The **North American Numbering Plan (NANP)** is a telephone numbering system used by many countries in North America like the United States, Canada or Bermuda. All NANP-countries share the same international country code `1`.
 
-- If the phone number is less than 10 digits assume that it is bad
-  number
-- If the phone number is 10 digits assume that it is good
-- If the phone number is 11 digits and the first number is 1, trim the 1
-  and use the last 10 digits
-- If the phone number is 11 digits and the first number is not 1, then
-  it is a bad number
-- If the phone number is more than 11 digits assume that it is a bad
-  number
+NANP numbers are ten-digit numbers consisting of a three-digit Numbering Plan Area code, commonly known as *area code*, followed by a seven-digit local number. The first three digigts of the local number represent the *exchange code*, followed by the unique four-digit number which is the *subscriber number*.
 
-We've provided tests, now make them pass.
 
-Hint: Only make one test pass at a time. Disable the others, then flip
-each on in turn after you get the current failing one to pass.
+The format is usually represented as
+```
+(NXX)-NXX-XXXX
+```
+where N is any digit from 2 through 9 and X is any digit from 0 through 9.
+
+You task is to clean up differently formated telephone numbers by removeing punctuatin and the country code (1) if present.
+
+**Example:**
++1 (613)-995-0253
+613-995-0253
+1 613 995 0253
+613.995.0253
+- - - - - - - - - - - - -
+6139950253
+
+**Note:** As this exercise only deals with telephone numbers used in NANP-countries only 1 is considered a valid country code.

--- a/exercises/phone-number/description.md
+++ b/exercises/phone-number/description.md
@@ -1,6 +1,6 @@
 The **North American Numbering Plan (NANP)** is a telephone numbering system used by many countries in North America like the United States, Canada or Bermuda. All NANP-countries share the same international country code `1`.
 
-NANP numbers are ten-digit numbers consisting of a three-digit Numbering Plan Area code, commonly known as *area code*, followed by a seven-digit local number. The first three digigts of the local number represent the *exchange code*, followed by the unique four-digit number which is the *subscriber number*.
+NANP numbers are ten-digit numbers consisting of a three-digit Numbering Plan Area code, commonly known as *area code*, followed by a seven-digit local number. The first three digits of the local number represent the *exchange code*, followed by the unique four-digit number which is the *subscriber number*.
 
 
 The format is usually represented as
@@ -9,7 +9,7 @@ The format is usually represented as
 ```
 where N is any digit from 2 through 9 and X is any digit from 0 through 9.
 
-You task is to clean up differently formated telephone numbers by removeing punctuatin and the country code (1) if present.
+Your task is to clean up differently formated telephone numbers by removing punctuation and the country code (1) if present.
 
 **Example:**
 +1 (613)-995-0253


### PR DESCRIPTION
Removes the part about how to test, as we have other docs for that. Now it also describes the telephone number system in a bit more detail.

Changes some test that used an invalid number but assumed it was valid.

Adds two tests that check the range of 2-9 for the first digit of the area and the exchange code.

Adds a test with a valid telephone number with country code and punctuation.