### PR TITLE
word-search: add canonical data

### DIFF
--- a/exercises/word-search/canonical-data.json
+++ b/exercises/word-search/canonical-data.json
@@ -1,0 +1,676 @@
+{
+  "exercise": "word-search",
+  "version": "1.0.0",
+  "comments": [
+    "Grid rows and columns are 1-indexed.",
+    "An expected value of -1 indicates that some sort of failure should occur."
+  ],
+  "cases": [
+    {
+      "description": "Should locate words written left to right",
+      "property": "search",
+      "grid": [
+        "jefblpepre",
+        "camdcimgtc",
+        "oivokprjsm",
+        "pbwasqroua",
+        "rixilelhrs",
+        "wolcqlirpc",
+        "screeaumgr",
+        "alxhpburyi",
+        "jalaycalmp",
+        "clojurermt"
+      ],
+      "wordsToSearchFor": [
+        "clojure"
+      ],
+      "expected": {
+        "clojure": {
+          "start": {
+            "column": 1,
+            "row": 10
+          },
+          "end": {
+            "column": 7,
+            "row": 10
+          }
+        }
+      }
+    },
+    {
+      "description": "Should locate words written right to left",
+      "property": "search",
+      "grid": [
+        "jefblpepre",
+        "camdcimgtc",
+        "oivokprjsm",
+        "pbwasqroua",
+        "rixilelhrs",
+        "wolcqlirpc",
+        "screeaumgr",
+        "alxhpburyi",
+        "jalaycalmp",
+        "clojurermt"
+      ],
+      "wordsToSearchFor": [
+        "clojure",
+        "elixir"
+      ],
+      "expected": {
+        "clojure": {
+          "start": {
+            "column": 1,
+            "row": 10
+          },
+          "end": {
+            "column": 7,
+            "row": 10
+          }
+        },
+        "elixir": {
+          "start": {
+            "column": 6,
+            "row": 5
+          },
+          "end": {
+            "column": 1,
+            "row": 5
+          }
+        }
+      }
+    },
+    {
+      "description": "Should locate words written top to bottom",
+      "property": "search",
+      "grid": [
+        "jefblpepre",
+        "camdcimgtc",
+        "oivokprjsm",
+        "pbwasqroua",
+        "rixilelhrs",
+        "wolcqlirpc",
+        "screeaumgr",
+        "alxhpburyi",
+        "jalaycalmp",
+        "clojurermt"
+      ],
+      "wordsToSearchFor": [
+        "clojure",
+        "elixir",
+        "ecmascript"
+      ],
+      "expected": {
+        "clojure": {
+          "start": {
+            "column": 1,
+            "row": 10
+          },
+          "end": {
+            "column": 7,
+            "row": 10
+          }
+        },
+        "elixir": {
+          "start": {
+            "column": 6,
+            "row": 5
+          },
+          "end": {
+            "column": 1,
+            "row": 5
+          }
+        },
+        "ecmascript": {
+          "start": {
+            "column": 10,
+            "row": 1
+          },
+          "end": {
+            "column": 10,
+            "row": 10
+          }
+        }
+      }
+    },
+    {
+      "description": "Should locate words written bottom to top",
+      "property": "search",
+      "grid": [
+        "jefblpepre",
+        "camdcimgtc",
+        "oivokprjsm",
+        "pbwasqroua",
+        "rixilelhrs",
+        "wolcqlirpc",
+        "screeaumgr",
+        "alxhpburyi",
+        "jalaycalmp",
+        "clojurermt"
+      ],
+      "wordsToSearchFor": [
+        "clojure",
+        "elixir",
+        "ecmascript",
+        "rust"
+      ],
+      "expected": {
+        "clojure": {
+          "start": {
+            "column": 1,
+            "row": 10
+          },
+          "end": {
+            "column": 7,
+            "row": 10
+          }
+        },
+        "elixir": {
+          "start": {
+            "column": 6,
+            "row": 5
+          },
+          "end": {
+            "column": 1,
+            "row": 5
+          }
+        },
+        "ecmascript": {
+          "start": {
+            "column": 10,
+            "row": 1
+          },
+          "end": {
+            "column": 10,
+            "row": 10
+          }
+        },
+        "rust": {
+          "start": {
+            "column": 9,
+            "row": 5
+          },
+          "end": {
+            "column": 9,
+            "row": 2
+          }
+        }
+      }
+    },
+    {
+      "description": "Should locate words written top left to bottom right",
+      "property": "search",
+      "grid": [
+        "jefblpepre",
+        "camdcimgtc",
+        "oivokprjsm",
+        "pbwasqroua",
+        "rixilelhrs",
+        "wolcqlirpc",
+        "screeaumgr",
+        "alxhpburyi",
+        "jalaycalmp",
+        "clojurermt"
+      ],
+      "wordsToSearchFor": [
+        "clojure",
+        "elixir",
+        "ecmascript",
+        "rust",
+        "java"
+      ],
+      "expected": {
+        "clojure": {
+          "start": {
+            "column": 1,
+            "row": 10
+          },
+          "end": {
+            "column": 7,
+            "row": 10
+          }
+        },
+        "elixir": {
+          "start": {
+            "column": 6,
+            "row": 5
+          },
+          "end": {
+            "column": 1,
+            "row": 5
+          }
+        },
+        "ecmascript": {
+          "start": {
+            "column": 10,
+            "row": 1
+          },
+          "end": {
+            "column": 10,
+            "row": 10
+          }
+        },
+        "rust": {
+          "start": {
+            "column": 9,
+            "row": 5
+          },
+          "end": {
+            "column": 9,
+            "row": 2
+          }
+        },
+        "java": {
+          "start": {
+            "column": 1,
+            "row": 1
+          },
+          "end": {
+            "column": 4,
+            "row": 4
+          }
+        }
+      }
+    },
+    {
+      "description": "Should locate words written bottom right to top left",
+      "property": "search",
+      "grid": [
+        "jefblpepre",
+        "camdcimgtc",
+        "oivokprjsm",
+        "pbwasqroua",
+        "rixilelhrs",
+        "wolcqlirpc",
+        "screeaumgr",
+        "alxhpburyi",
+        "jalaycalmp",
+        "clojurermt"
+      ],
+      "wordsToSearchFor": [
+        "clojure",
+        "elixir",
+        "ecmascript",
+        "rust",
+        "java",
+        "lua"
+      ],
+      "expected": {
+        "clojure": {
+          "start": {
+            "column": 1,
+            "row": 10
+          },
+          "end": {
+            "column": 7,
+            "row": 10
+          }
+        },
+        "elixir": {
+          "start": {
+            "column": 6,
+            "row": 5
+          },
+          "end": {
+            "column": 1,
+            "row": 5
+          }
+        },
+        "ecmascript": {
+          "start": {
+            "column": 10,
+            "row": 1
+          },
+          "end": {
+            "column": 10,
+            "row": 10
+          }
+        },
+        "rust": {
+          "start": {
+            "column": 9,
+            "row": 5
+          },
+          "end": {
+            "column": 9,
+            "row": 2
+          }
+        },
+        "java": {
+          "start": {
+            "column": 1,
+            "row": 1
+          },
+          "end": {
+            "column": 4,
+            "row": 4
+          }
+        },
+        "lua": {
+          "start": {
+            "column": 8,
+            "row": 9
+          },
+          "end": {
+            "column": 6,
+            "row": 7
+          }
+        }
+      }
+    },
+    {
+      "description": "Should locate words written bottom left to top right",
+      "property": "search",
+      "grid": [
+        "jefblpepre",
+        "camdcimgtc",
+        "oivokprjsm",
+        "pbwasqroua",
+        "rixilelhrs",
+        "wolcqlirpc",
+        "screeaumgr",
+        "alxhpburyi",
+        "jalaycalmp",
+        "clojurermt"
+      ],
+      "wordsToSearchFor": [
+        "clojure",
+        "elixir",
+        "ecmascript",
+        "rust",
+        "java",
+        "lua",
+        "lisp"
+      ],
+      "expected": {
+        "clojure": {
+          "start": {
+            "column": 1,
+            "row": 10
+          },
+          "end": {
+            "column": 7,
+            "row": 10
+          }
+        },
+        "elixir": {
+          "start": {
+            "column": 6,
+            "row": 5
+          },
+          "end": {
+            "column": 1,
+            "row": 5
+          }
+        },
+        "ecmascript": {
+          "start": {
+            "column": 10,
+            "row": 1
+          },
+          "end": {
+            "column": 10,
+            "row": 10
+          }
+        },
+        "rust": {
+          "start": {
+            "column": 9,
+            "row": 5
+          },
+          "end": {
+            "column": 9,
+            "row": 2
+          }
+        },
+        "java": {
+          "start": {
+            "column": 1,
+            "row": 1
+          },
+          "end": {
+            "column": 4,
+            "row": 4
+          }
+        },
+        "lua": {
+          "start": {
+            "column": 8,
+            "row": 9
+          },
+          "end": {
+            "column": 6,
+            "row": 7
+          }
+        },
+        "lisp": {
+          "start": {
+            "column": 3,
+            "row": 6
+          },
+          "end": {
+            "column": 6,
+            "row": 3
+          }
+        }
+      }
+    },
+    {
+      "description": "Should locate words written top right to bottom left",
+      "property": "search",
+      "grid": [
+        "jefblpepre",
+        "camdcimgtc",
+        "oivokprjsm",
+        "pbwasqroua",
+        "rixilelhrs",
+        "wolcqlirpc",
+        "screeaumgr",
+        "alxhpburyi",
+        "jalaycalmp",
+        "clojurermt"
+      ],
+      "wordsToSearchFor": [
+        "clojure",
+        "elixir",
+        "ecmascript",
+        "rust",
+        "java",
+        "lua",
+        "lisp",
+        "ruby"
+      ],
+      "expected": {
+        "clojure": {
+          "start": {
+            "column": 1,
+            "row": 10
+          },
+          "end": {
+            "column": 7,
+            "row": 10
+          }
+        },
+        "elixir": {
+          "start": {
+            "column": 6,
+            "row": 5
+          },
+          "end": {
+            "column": 1,
+            "row": 5
+          }
+        },
+        "ecmascript": {
+          "start": {
+            "column": 10,
+            "row": 1
+          },
+          "end": {
+            "column": 10,
+            "row": 10
+          }
+        },
+        "rust": {
+          "start": {
+            "column": 9,
+            "row": 5
+          },
+          "end": {
+            "column": 9,
+            "row": 2
+          }
+        },
+        "java": {
+          "start": {
+            "column": 1,
+            "row": 1
+          },
+          "end": {
+            "column": 4,
+            "row": 4
+          }
+        },
+        "lua": {
+          "start": {
+            "column": 8,
+            "row": 9
+          },
+          "end": {
+            "column": 6,
+            "row": 7
+          }
+        },
+        "lisp": {
+          "start": {
+            "column": 3,
+            "row": 6
+          },
+          "end": {
+            "column": 6,
+            "row": 3
+          }
+        },
+        "ruby": {
+          "start": {
+            "column": 8,
+            "row": 6
+          },
+          "end": {
+            "column": 5,
+            "row": 9
+          }
+        }
+      }
+    },
+    {
+      "description": "Should fail to locate a word that is not in the puzzle",
+      "property": "search",
+      "grid": [
+        "jefblpepre",
+        "camdcimgtc",
+        "oivokprjsm",
+        "pbwasqroua",
+        "rixilelhrs",
+        "wolcqlirpc",
+        "screeaumgr",
+        "alxhpburyi",
+        "jalaycalmp",
+        "clojurermt"
+      ],
+      "wordsToSearchFor": [
+        "clojure",
+        "elixir",
+        "ecmascript",
+        "rust",
+        "java",
+        "lua",
+        "lisp",
+        "ruby",
+        "haskell"
+      ],
+      "expected": {
+        "clojure": {
+          "start": {
+            "column": 1,
+            "row": 10
+          },
+          "end": {
+            "column": 7,
+            "row": 10
+          }
+        },
+        "elixir": {
+          "start": {
+            "column": 6,
+            "row": 5
+          },
+          "end": {
+            "column": 1,
+            "row": 5
+          }
+        },
+        "ecmascript": {
+          "start": {
+            "column": 10,
+            "row": 1
+          },
+          "end": {
+            "column": 10,
+            "row": 10
+          }
+        },
+        "rust": {
+          "start": {
+            "column": 9,
+            "row": 5
+          },
+          "end": {
+            "column": 9,
+            "row": 2
+          }
+        },
+        "java": {
+          "start": {
+            "column": 1,
+            "row": 1
+          },
+          "end": {
+            "column": 4,
+            "row": 4
+          }
+        },
+        "lua": {
+          "start": {
+            "column": 8,
+            "row": 9
+          },
+          "end": {
+            "column": 6,
+            "row": 7
+          }
+        },
+        "lisp": {
+          "start": {
+            "column": 3,
+            "row": 6
+          },
+          "end": {
+            "column": 6,
+            "row": 3
+          }
+        },
+        "ruby": {
+          "start": {
+            "column": 8,
+            "row": 6
+          },
+          "end": {
+            "column": 5,
+            "row": 9
+          }
+        },
+        "haskell": null
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Closes #591.

Notes/thoughts:
- Single grid is used for all tests. The likelihood that a practitioner will hard-code the actual search logic in any way is low.
- Grid used for all tests matches the updated grid from the exercise `description.md`; Go track will need to update that to match this spec.
- Test cases for each of the 8 possible word directions are cumulative, which allows better matching of the problem statement ("given a puzzle and a list of words") and a more explicit prompt to "build up" the search capability piece-by-piece. All existing tracks would need to change to accommodate this new input structure, I believe.

Feedback welcome! 👂