### PR TITLE
saddle-points: add canonical data

### DIFF
--- a/exercises/saddle-points/canonical-data.json
+++ b/exercises/saddle-points/canonical-data.json
@@ -1,0 +1,87 @@
+{
+  "exercise": "saddle-points",
+  "version": "1.0.0",
+  "comments": [
+    "Matrix rows and columns are 0-indexed."
+  ],
+  "cases": [
+    {
+      "description": "Can identify single saddle point",
+      "comments": [
+        "This is the README example."
+      ],
+      "property": "saddlePoints",
+      "input": [
+        [9, 8, 7],
+        [5, 3, 2],
+        [6, 6, 7]
+      ],
+      "expected": [
+        {
+          "row": 1,
+          "column": 0
+        }
+      ]
+    },
+    {
+      "description": "Can identify that empty matrix has no saddle points",
+      "property": "saddlePoints",
+      "input": [
+        []
+      ],
+      "expected": []
+    },
+    {
+      "description": "Can identify lack of saddle points when there are none",
+      "property": "saddlePoints",
+      "input": [
+        [1, 2, 3],
+        [3, 1, 2],
+        [2, 3, 1]
+      ],
+      "expected": []
+    },
+    {
+      "description": "Can identify multiple saddle points",
+      "property": "saddlePoints",
+      "input": [
+        [4, 5, 4],
+        [3, 5, 5],
+        [1, 5, 4]
+      ],
+      "expected": [
+        {
+          "row": 0,
+          "column": 1
+        },
+        {
+          "row": 1,
+          "column": 1
+        },
+        {
+          "row": 2,
+          "column": 1
+        }
+      ]
+    },
+    {
+      "description": "Can identify saddle point in bottom right corner",
+      "comments": [
+        "This is a permutation of the README matrix designed to test",
+        "off-by-one errors."
+      ],
+      "property": "saddlePoints",
+      "input": [
+        [8, 7, 9],
+        [6, 7, 6],
+        [3, 2, 5]
+      ],
+      "expected": [
+        {
+          "row": 2,
+          "column": 2
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Closes #582.

Notes:
- Per https://github.com/exercism/discussions/issues/41, the row/column identification tests found in several tracks represent testing intermediate implementation details and should be removed.
- Larger matrices have been removed from the tests; they did not exercise anything that was not already covered (except possibly for differing matrix dimensions?)
- Readme example is included as the first exercise; the majority of tracks already test this and it's a nice start point.
- Empty example is included; only a few tracks currently test this, but it's a nice boundary case.
- Multiple saddle points test uses the more-common matrix as found in e.g. xcsharp. xpython and xscala will need to update their multiple saddle points tests.
- Example with saddle point in the lower right matrix entry has been added to check for off-by-one errors. This is new for all tracks.
- Example with no saddle points has been expanded from 2x2 matrix to 3x3 matrix to give implementers more of a hint as to how one might go about constructing such a matrix. This is new for all tracks.
- No check for invalid matrix size is included in the canonical suite; can be included if desired, in which case I'll pull the xpython input for that test.