### PR TITLE
Robot name uniqueness clarification

### DIFF
--- a/exercises/robot-name/description.md
+++ b/exercises/robot-name/description.md
@@ -9,5 +9,4 @@ respond with a new random name.
 
 The names must be random: they should not follow a predictable sequence.
 Random names means a risk of collisions. Your solution should not allow
-the use of the same name twice when avoidable. In some exercism language
-tracks there are tests to ensure that the same name is never used twice.
+the use of the same name twice.

--- a/exercises/robot-name/description.md
+++ b/exercises/robot-name/description.md
@@ -8,5 +8,5 @@ which means that their name gets wiped. The next time you ask, it will
 respond with a new random name.
 
 The names must be random: they should not follow a predictable sequence.
-Random names means a risk of collisions. Your solution should ensure that
+Random names means a risk of collisions. Your solution must ensure that
 every existing robot has a unique name.

--- a/exercises/robot-name/description.md
+++ b/exercises/robot-name/description.md
@@ -8,5 +8,5 @@ which means that their name gets wiped. The next time you ask, it will
 respond with a new random name.
 
 The names must be random: they should not follow a predictable sequence.
-Random names means a risk of collisions. Your solution should not allow
-the use of the same name twice.
+Random names means a risk of collisions. Your solution should ensure that
+every existing robot has a unique name.


### PR DESCRIPTION
The previous description of this problem was unclear about 
This patch removes the ambiguity by clearly stating that "every existing robot has a unique name."


This PR is an alternative to #748 which seeks to make the name uniqueness an extension,
and https://github.com/exercism/x-common/issues/731 which proposes removing it completely.

(commits can be squashed.)