### PR TITLE
Remove Rubyism in description.

### DIFF
--- a/exercises/scrabble-score/description.md
+++ b/exercises/scrabble-score/description.md
@@ -30,5 +30,5 @@ And to total:
 - = 14
 
 ## Extensions
-- You can play a `:double` or a `:triple` letter.
-- You can play a `:double` or a `:triple` word.
+- You can play a double or a triple letter.
+- You can play a double or a triple word.


### PR DESCRIPTION
scrabble-score description contained some Ruby style symbols.