### PR TITLE
rail-fence-cipher 1.0.1: Remove "test to" from all descriptions

### DIFF
--- a/exercises/rail-fence-cipher/canonical-data.json
+++ b/exercises/rail-fence-cipher/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "rail-fence-cipher",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "comments": [
     "The tests do not expect any normalization or cleaning.",
     "That trade is tested in enough other exercises."
@@ -10,21 +10,21 @@
       "description": "encode",
       "cases": [
         {
-          "description": "test to encode with two rails",
+          "description": "encode with two rails",
           "property": "encode",
           "msg": "XOXOXOXOXOXOXOXOXO",
           "rails": 2,
           "expected": "XXXXXXXXXOOOOOOOOO"
         },
         {
-          "description": "test to encode with three rails",
+          "description": "encode with three rails",
           "property": "encode",
           "msg": "WEAREDISCOVEREDFLEEATONCE",
           "rails": 3,
           "expected": "WECRLTEERDSOEEFEAOCAIVDEN"
         },
         {
-          "description": "test to encode with ending in the middle",
+          "description": "encode with ending in the middle",
           "property": "encode",
           "msg": "EXERCISES",
           "rails": 4,
@@ -36,21 +36,21 @@
       "description": "decode",
       "cases": [
         {
-          "description": "test to decode with three rails",
+          "description": "decode with three rails",
           "property": "decode",
           "msg": "TEITELHDVLSNHDTISEIIEA",
           "rails": 3,
           "expected": "THEDEVILISINTHEDETAILS"
         },
         {
-          "description": "test to decode with five rails",
+          "description": "decode with five rails",
           "property": "decode",
           "msg": "EIEXMSMESAORIWSCE",
           "rails": 5,
           "expected": "EXERCISMISAWESOME"
         },
         {
-          "description": "test to decode with six rails",
+          "description": "decode with six rails",
           "property": "decode",
           "msg": "133714114238148966225439541018335470986172518171757571896261",
           "rails": 6,


### PR DESCRIPTION
It doesn't seem to add value to state that these are tests! That should
be self-evidence from their presence in this file, no?

I don't have evidence that this a documented principle that MUST be
followed, nor do I have evidence that anyone is being hurt by the
presence of the words "test to", but I propose it to see what people
think.