### PR TITLE
phone-number: Remove test using malformed input.

### DIFF
--- a/exercises/phone-number/canonical-data.json
+++ b/exercises/phone-number/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "phone-number",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "cases": [
     {
       "description": "Cleanup user-entered phone numbers",

--- a/exercises/phone-number/canonical-data.json
+++ b/exercises/phone-number/canonical-data.json
@@ -71,12 +71,6 @@
           "expected": null
         },
         {
-          "description": "invalid with right number of digits but letters mixed in",
-          "property": "clean",
-          "phrase": "1a2b3c4d5e6f7g8h9i0j",
-          "expected": null
-        },
-        {
           "description": "invalid if area code does not start with 2-9",
           "property": "clean",
           "phrase": "(123) 456-7890",


### PR DESCRIPTION
> Your task is to clean up differently formated telephone numbers by removing punctuation and the country code (1) if present.

Letters are not punctuation and this is not primarily a string parsing exercise.
So remove the test using `1a2b3c4d5e6f7g8h9i0j` as input.
