### PR TITLE
Make description.md self contained.

### DIFF
--- a/bin/transfer_blurb_to_description.rb
+++ b/bin/transfer_blurb_to_description.rb
@@ -1,0 +1,56 @@
+#!/usr/bin/env ruby
+
+# This is a temporary file which exists to support the x-common issue #767
+# [Make description.md self contained.](# https://github.com/exercism/x-common/issues/767)
+#
+# The exercise description given in description.md should be complete and self
+# contained, and not require the addition of the blurb to make sense.
+#
+# This script copies the current blurb into description.md for all exercises.
+#
+# It will NOT update the description if it already begins with the blurb.
+# Thus this script will not add multiple blurbs if it is run multiple times.
+
+require 'yaml'
+
+class Exercise
+  attr_reader :path
+  def initialize(path)
+    @path = path
+  end
+
+  def update_description
+    unless description.start_with?(blurb)
+      complete_description = format("%s\n\n%s", blurb, description)
+      File.write(description_filename, complete_description)
+    end
+  end
+
+  private
+
+  def blurb
+    metadata['blurb']
+  end
+
+  def metadata
+    metadata_filename = File.join(path, 'metadata.yml')
+    YAML.load_file(metadata_filename)
+  end
+
+  def description
+    File.read(description_filename)
+  end
+
+  def description_filename
+    File.join(path, 'description.md')
+  end
+end
+
+
+exercises = Dir.glob('exercises/*').map {|path| Exercise.new(path)}
+
+updated = exercises.count do |exercise|
+  exercise.update_description
+end
+
+puts "#{updated}/#{exercises.count} exercises updated"

--- a/exercises/accumulate/description.md
+++ b/exercises/accumulate/description.md
@@ -1,3 +1,5 @@
+Implement the `accumulate` operation, which, given a collection and an operation to perform on each element of the collection, returns a new collection containing the result of applying that operation to each element of the input collection.
+
 Given the collection of numbers:
 
 - 1, 2, 3, 4, 5

--- a/exercises/acronym/description.md
+++ b/exercises/acronym/description.md
@@ -1,3 +1,5 @@
+Convert a long phrase to its acronym
+
 Techies love their TLA (Three Letter Acronyms)!
 
 Help generate some jargon by writing a program that converts a long name

--- a/exercises/all-your-base/description.md
+++ b/exercises/all-your-base/description.md
@@ -1,3 +1,5 @@
+Convert a number, represented as a sequence of digits in one base, to any other base.
+
 Implement general base conversion. Given a number in base **a**,
 represented as a sequence of digits, convert it to base **b**.
 

--- a/exercises/allergies/description.md
+++ b/exercises/allergies/description.md
@@ -1,3 +1,5 @@
+Given a person's allergy score, determine whether or not they're allergic to a given item, and their full list of allergies.
+
 An allergy test produces a single numeric score which contains the
 information about all the allergies the person has (that they were
 tested for).

--- a/exercises/alphametics/description.md
+++ b/exercises/alphametics/description.md
@@ -1,3 +1,5 @@
+Write a function to solve alphametics puzzles.
+
 [Alphametics](https://en.wikipedia.org/wiki/Alphametics) is a puzzle where
 letters in words are replaced with numbers.
 

--- a/exercises/anagram/description.md
+++ b/exercises/anagram/description.md
@@ -1,3 +1,5 @@
+Given a word and a list of possible anagrams, select the correct sublist.
+
 Given `"listen"` and a list of candidates like `"enlists" "google"
 "inlets" "banana"` the program should return a list containing
 `"inlets"`.

--- a/exercises/atbash-cipher/description.md
+++ b/exercises/atbash-cipher/description.md
@@ -1,3 +1,5 @@
+Create an implementation of the atbash cipher, an ancient encryption system created in the Middle East.
+
 The Atbash cipher is a simple substitution cipher that relies on
 transposing all the letters in the alphabet such that the resulting
 alphabet is backwards. The first letter is replaced with the last

--- a/exercises/bank-account/description.md
+++ b/exercises/bank-account/description.md
@@ -1,3 +1,5 @@
+Simulate a bank account supporting opening/closing, withdraws, and deposits of money. Watch out for concurrent transactions!
+
 A bank account can be accessed in multiple ways. Clients can make
 deposits and withdrawals using the internet, mobile phones, etc. Shops
 can charge against the account.

--- a/exercises/beer-song/description.md
+++ b/exercises/beer-song/description.md
@@ -1,3 +1,5 @@
+Produce the lyrics to that beloved classic, that field-trip favorite: 99 Bottles of Beer on the Wall.
+
 Note that not all verses are identical.
 
 ```plain

--- a/exercises/binary-search-tree/description.md
+++ b/exercises/binary-search-tree/description.md
@@ -1,3 +1,5 @@
+Insert and search for numbers in a binary tree.
+
 When we need to represent sorted data, an array does not make a good
 data structure.
 

--- a/exercises/binary-search/description.md
+++ b/exercises/binary-search/description.md
@@ -1,3 +1,5 @@
+Implement a binary search algorithm.
+
 Searching a sorted collection is a common task. A dictionary is a sorted
 list of word definitions. Given a word, one can find its definition. A
 telephone book is a sorted list of people's names, addresses, and

--- a/exercises/binary/description.md
+++ b/exercises/binary/description.md
@@ -1,3 +1,5 @@
+Convert a binary number, represented as a string (e.g. '101010'), to its decimal equivalent using first principles
+
 Implement binary to decimal conversion. Given a binary input
 string, your program should produce a decimal output. The
 program should handle invalid inputs.

--- a/exercises/bob/description.md
+++ b/exercises/bob/description.md
@@ -1,3 +1,5 @@
+Bob is a lackadaisical teenager. In conversation, his responses are very limited.
+
 Bob answers 'Sure.' if you ask him a question.
 
 He answers 'Whoa, chill out!' if you yell at him.

--- a/exercises/book-store/description.md
+++ b/exercises/book-store/description.md
@@ -1,3 +1,5 @@
+To try and encourage more sales of different books from a popular 5 book series, a bookshop has decided to offer discounts of multiple-book purchases.
+
 To try and encourage more sales of the 5 different books
 they sell of a popular series, a bookshop has decided to
 offer discounts of multi-book purchases. 

--- a/exercises/bowling/description.md
+++ b/exercises/bowling/description.md
@@ -1,3 +1,5 @@
+Score a bowling game
+
 Bowling is game where players roll a heavy ball to knock down pins
 arranged in a triangle. Write code to keep track of the score
 of a game of bowling.

--- a/exercises/bracket-push/description.md
+++ b/exercises/bracket-push/description.md
@@ -1,2 +1,4 @@
+Make sure the brackets and braces all match.
+
 Ensure that all the brackets and braces are matched correctly,
 and nested correctly.

--- a/exercises/change/description.md
+++ b/exercises/change/description.md
@@ -1,3 +1,5 @@
+Correctly determine change to be given using the least number of coins
+
 Correctly determine the fewest number of coins to be given to the user
 such that the sum of the coins' value would equal the correct amount
 of change.

--- a/exercises/circular-buffer/description.md
+++ b/exercises/circular-buffer/description.md
@@ -1,3 +1,5 @@
+A data structure that uses a single, fixed-size buffer as if it were connected end-to-end.
+
 A circular buffer, cyclic buffer or ring buffer is a data structure that
 uses a single, fixed-size buffer as if it were connected end-to-end.
 

--- a/exercises/clock/description.md
+++ b/exercises/clock/description.md
@@ -1,3 +1,5 @@
+Implement a clock that handles times without dates.
+
 Create a clock that is independent of date.
 
 You should be able to add and subtract minutes to it.

--- a/exercises/connect/description.md
+++ b/exercises/connect/description.md
@@ -1,3 +1,5 @@
+Compute the result for a game of Hex / Polygon
+
 The abstract boardgame known as
 [Hex](https://en.wikipedia.org/wiki/Hex_%28board_game%29) / Polygon /
 CON-TAC-TIX is quite simple in rules, though complex in practice. Two players

--- a/exercises/counter/description.md
+++ b/exercises/counter/description.md
@@ -1,3 +1,5 @@
+Design a test suite for a line/letter/character counter tool.
+
 **NOTE: This exercise has been deprecated.**
 
 Please see the discussion in https://github.com/exercism/x-common/issues/80

--- a/exercises/crypto-square/description.md
+++ b/exercises/crypto-square/description.md
@@ -1,3 +1,5 @@
+Implement the classic method for composing secret messages called a square code.
+
 Given an English text, output the encoded version of that text.
 
 First, the input is normalized: the spaces and punctuation are removed

--- a/exercises/custom-set/description.md
+++ b/exercises/custom-set/description.md
@@ -1,3 +1,5 @@
+Create a custom set type.
+
 Sometimes it is necessary to define a custom data structure of some
 type, like a set. In this exercise you will define your own set. How it
 works internally doesn't matter, as long as it behaves like a set of

--- a/exercises/diamond/description.md
+++ b/exercises/diamond/description.md
@@ -1,3 +1,5 @@
+Given a letter, print a diamond starting with 'A' with the supplied letter at the widest point.
+
 ## Diamond kata
 
 The diamond kata takes as its input a letter, and outputs it in a diamond 

--- a/exercises/difference-of-squares/description.md
+++ b/exercises/difference-of-squares/description.md
@@ -1,3 +1,5 @@
+Find the difference between the square of the sum and the sum of the squares of the first N natural numbers.
+
 The square of the sum of the first ten natural numbers is
 (1 + 2 + ... + 10)² = 55² = 3025.
 

--- a/exercises/diffie-hellman/description.md
+++ b/exercises/diffie-hellman/description.md
@@ -1,3 +1,5 @@
+Diffie-Hellman key exchange.
+
 Alice and Bob use Diffie-Hellman key exchange to share secrets.  They
 start with prime numbers, pick private keys, generate and share public
 keys, and then generate a shared secret key.

--- a/exercises/dominoes/description.md
+++ b/exercises/dominoes/description.md
@@ -1,3 +1,5 @@
+Make a chain of dominoes.
+
 Compute a way to order a given set of dominoes in such a way that they form a
 correct domino chain (the dots on one half of a stone match the dots on the
 neighbouring half of an adjacent stone) and that dots on the halfs of the stones

--- a/exercises/dot-dsl/description.md
+++ b/exercises/dot-dsl/description.md
@@ -1,3 +1,5 @@
+Write a Domain Specific Language similar to the Graphviz dot language
+
 A [Domain Specific Language
 (DSL)](https://en.wikipedia.org/wiki/Domain-specific_language) is a
 small language optimized for a specific domain.

--- a/exercises/error-handling/description.md
+++ b/exercises/error-handling/description.md
@@ -1,3 +1,5 @@
+Implement various kinds of error handling and resource management
+
 An important point of programming is how to handle errors and close
 resources even if errors occur.
 

--- a/exercises/etl/description.md
+++ b/exercises/etl/description.md
@@ -1,3 +1,5 @@
+We are going to do the `Transform` step of an Extract-Transform-Load.
+
 ### ETL
 Extract-Transform-Load (ETL) is a fancy way of saying, "We have some crufty, legacy data over in this system, and now we need it in this shiny new system over here, so
 we're going to migrate this."

--- a/exercises/flatten-array/description.md
+++ b/exercises/flatten-array/description.md
@@ -1,3 +1,5 @@
+Take a nested list and return a single list with all values except nil/null
+
 The challenge is to write a function that accepts an arbitrarily-deep nested list-like structure and returns a flattened structure without any nil/null values.
  
 For Example

--- a/exercises/food-chain/description.md
+++ b/exercises/food-chain/description.md
@@ -1,3 +1,5 @@
+Generate the lyrics of the song 'I Know an Old Lady Who Swallowed a Fly'
+
 While you could copy/paste the lyrics,
 or read them from a file, this problem is much more
 interesting if you approach it algorithmically.

--- a/exercises/forth/description.md
+++ b/exercises/forth/description.md
@@ -1,3 +1,5 @@
+Implement an evaluator for a very simple subset of Forth
+
 [Forth](https://en.wikipedia.org/wiki/Forth_%28programming_language%29)
 is a stack-based programming language. Implement a very basic evaluator
 for a small subset of Forth.

--- a/exercises/gigasecond/description.md
+++ b/exercises/gigasecond/description.md
@@ -1,1 +1,3 @@
+Calculate the moment when someone has lived for 10^9 seconds.
+
 A gigasecond is 10^9 (1,000,000,000) seconds.

--- a/exercises/go-counting/description.md
+++ b/exercises/go-counting/description.md
@@ -1,3 +1,5 @@
+Count the scored points on a Go board.
+
 In the game of go (also known as baduk, igo, cờ vây and wéiqí) points
 are gained by completely encircling empty intersections with your
 stones. The encircled intersections of a player are known as its

--- a/exercises/grade-school/description.md
+++ b/exercises/grade-school/description.md
@@ -1,3 +1,5 @@
+Given students' names along with the grade that they are in, create a roster for the school
+
 In the end, you should be able to:
 
 - Add a student's name to the roster for a grade

--- a/exercises/grains/description.md
+++ b/exercises/grains/description.md
@@ -1,3 +1,5 @@
+Calculate the number of grains of wheat on a chessboard given that the number on each square doubles.
+
 There once was a wise servant who saved the life of a prince. The king
 promised to pay whatever the servant could dream up. Knowing that the
 king loved chess, the servant told the king he would like to have grains

--- a/exercises/grep/description.md
+++ b/exercises/grep/description.md
@@ -1,3 +1,5 @@
+Search a file for lines matching a regular expression pattern. Return the line number and contents of each matching line.
+
 The Unix [`grep`](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/grep.html) command can be used to search for lines in one or more files 
 that match a user-provided search query (known as the *pattern*).
 

--- a/exercises/hamming/description.md
+++ b/exercises/hamming/description.md
@@ -1,3 +1,5 @@
+Calculate the Hamming difference between two DNA strands.
+
 A mutation is simply a mistake that occurs during the creation or
 copying of a nucleic acid, in particular DNA. Because nucleic acids are
 vital to cellular functions, mutations tend to cause a ripple effect

--- a/exercises/hangman/description.md
+++ b/exercises/hangman/description.md
@@ -1,3 +1,5 @@
+Implement the logic of the hangman game using functional reactive programming.
+
 [Hangman][] is a simple word guessing game.
 
 [Functional Reactive Programming][frp] is a way to write interactive

--- a/exercises/hello-world/description.md
+++ b/exercises/hello-world/description.md
@@ -1,3 +1,5 @@
+The classical introductory exercise. Just say "Hello, World!"
+
 ["Hello, World!"](http://en.wikipedia.org/wiki/%22Hello,_world!%22_program) is
 the traditional first program for beginning programming in a new language
 or environment.

--- a/exercises/hexadecimal/description.md
+++ b/exercises/hexadecimal/description.md
@@ -1,3 +1,5 @@
+Convert a hexadecimal number, represented as a string (e.g. "10af8c"), to its decimal equivalent using first principles (i.e. no, you may not use built-in or external libraries to accomplish the conversion).
+
 On the web we use hexadecimal to represent colors, e.g. green: 008000,
 teal: 008080, navy: 000080).
 

--- a/exercises/house/description.md
+++ b/exercises/house/description.md
@@ -1,3 +1,5 @@
+Output the nursery rhyme 'This is the House that Jack Built'.
+
 > [The] process of placing a phrase of clause within another phrase of
 > clause is called embedding. It is through the processes of recursion
 > and embedding that we are able to take a finite number of forms (words

--- a/exercises/isogram/description.md
+++ b/exercises/isogram/description.md
@@ -1,3 +1,5 @@
+Determine if a word or phrase is an isogram.
+
 An isogram (also known as a "nonpattern word") is a word or phrase without a repeating letter.
 
 Examples of isograms:

--- a/exercises/kindergarten-garden/description.md
+++ b/exercises/kindergarten-garden/description.md
@@ -1,3 +1,5 @@
+Given a diagram, determine which plants each child in the kindergarten class is responsible for.
+
 The kindergarten class is learning about growing plants. The teachers
 thought it would be a good idea to give them actual seeds, plant them in
 actual dirt, and grow actual plants.

--- a/exercises/largest-series-product/description.md
+++ b/exercises/largest-series-product/description.md
@@ -1,3 +1,5 @@
+Given a string of digits, calculate the largest product for a contiguous substring of digits of length n.
+
 For example, for the input `'1027839564'`, the largest product for a
 series of 3 digits is 270 (9 * 5 * 6), and the largest product for a
 series of 5 digits is 7560 (7 * 8 * 3 * 9 * 5).

--- a/exercises/leap/description.md
+++ b/exercises/leap/description.md
@@ -1,3 +1,5 @@
+Given a year, report if it is a leap year.
+
 The tricky thing here is that a leap year in the Gregorian calendar occurs:
 
 ```plain

--- a/exercises/ledger/description.md
+++ b/exercises/ledger/description.md
@@ -1,3 +1,5 @@
+Refactor a ledger printer.
+
 The ledger exercise is a refactoring exercise. There is code that prints a
 nicely formatted ledger, given a locale (American or Dutch) and a currency (US
 dollar or euro). The code however is rather badly written, though (somewhat

--- a/exercises/lens-person/description.md
+++ b/exercises/lens-person/description.md
@@ -1,3 +1,5 @@
+Use lenses to update nested records (specific to languages with immutable data).
+
 Updating fields of nested records is kind of annoying in Haskell. One solution
 is to use [lenses](https://wiki.haskell.org/Lens).  Implement several record
 accessing functions using lenses, you may use any library you want. The test

--- a/exercises/linked-list/description.md
+++ b/exercises/linked-list/description.md
@@ -1,3 +1,5 @@
+Implement a doubly linked list
+
 Like an array, a linked list is a simple linear data structure. Several 
 common data types can be implemented using linked lists, like queues, 
 stacks, and associative arrays.

--- a/exercises/list-ops/description.md
+++ b/exercises/list-ops/description.md
@@ -1,3 +1,5 @@
+Implement basic list operations
+
 In functional languages list operations like `length`, `map`, and
 `reduce` are very common. Implement a series of basic list operations,
 without using existing functions.

--- a/exercises/luhn/description.md
+++ b/exercises/luhn/description.md
@@ -1,3 +1,5 @@
+Given a number determine whether or not it is valid per the Luhn formula.
+
 The [Luhn algorithm](https://en.wikipedia.org/wiki/Luhn_algorithm) is
 a simple checksum formula used to validate a variety of identification
 numbers, such as credit card numbers and Canadian Social Insurance

--- a/exercises/markdown/description.md
+++ b/exercises/markdown/description.md
@@ -1,3 +1,5 @@
+Refactor a Markdown parser
+
 The markdown exercise is a refactoring exercise. There is code that parses a
 given string with [Markdown
 syntax](https://guides.github.com/features/mastering-markdown/) and returns the

--- a/exercises/matrix/description.md
+++ b/exercises/matrix/description.md
@@ -1,3 +1,5 @@
+Given a string representing a matrix of numbers, return the rows and columns of that matrix.
+
 So given a string with embedded newlines like:
 
 > 9 8 7  

--- a/exercises/meetup/description.md
+++ b/exercises/meetup/description.md
@@ -1,3 +1,5 @@
+Calculate the date of meetups.
+
 Typically meetups happen on the same day of the week.  In this exercise, you will take
 a description of a meetup date, and return the actual meetup date.
 

--- a/exercises/minesweeper/description.md
+++ b/exercises/minesweeper/description.md
@@ -1,3 +1,5 @@
+Add the numbers to a minesweeper board
+
 Minesweeper is a popular game where the user has to find the mines using
 numeric hints that indicate how many mines are directly adjacent
 (horizontally, vertically, diagonally) to a square.

--- a/exercises/nth-prime/description.md
+++ b/exercises/nth-prime/description.md
@@ -1,3 +1,5 @@
+Given a number n, determine what the nth prime is.
+
 By listing the first six prime numbers: 2, 3, 5, 7, 11, and 13, we can see that
 the 6th prime is 13.
 

--- a/exercises/nucleotide-codons/description.md
+++ b/exercises/nucleotide-codons/description.md
@@ -1,3 +1,5 @@
+Write a function that returns the name of an amino acid a particular codon, possibly using shorthand, encodes for.
+
 In DNA sequences of 3 nucleotides, called codons, encode for amino acids. Often
 several codons encode for the same amino acid. The International Union of Pure
 and Applied Chemistry developed a shorthand system for designating groups of

--- a/exercises/nucleotide-count/description.md
+++ b/exercises/nucleotide-count/description.md
@@ -1,3 +1,5 @@
+Given a DNA string, compute how many times each nucleotide occurs in the string.
+
 DNA is represented by an alphabet of the following symbols: 'A', 'C',
 'G', and 'T'.
 

--- a/exercises/ocr-numbers/description.md
+++ b/exercises/ocr-numbers/description.md
@@ -1,3 +1,5 @@
+Given a 3 x 4 grid of pipes, underscores, and spaces, determine which number is represented, or whether it is garbled.
+
 # Step One
 
 To begin with, convert a simple binary font to a string containing 0 or 1.

--- a/exercises/octal/description.md
+++ b/exercises/octal/description.md
@@ -1,3 +1,5 @@
+Convert a octal number, represented as a string (e.g. '1735263'), to its decimal equivalent using first principles (i.e. no, you may not use built-in or external libraries to accomplish the conversion).
+
 Implement octal to decimal conversion.  Given an octal input
 string, your program should produce a decimal output.
 

--- a/exercises/paasio/description.md
+++ b/exercises/paasio/description.md
@@ -1,3 +1,5 @@
+Report network IO statistics
+
 You are writing a [PaaS][], and you need a way to bill customers based
 on network and filesystem usage.
 

--- a/exercises/palindrome-products/description.md
+++ b/exercises/palindrome-products/description.md
@@ -1,3 +1,5 @@
+Detect palindrome products in a given range.
+
 A palindromic number is a number that remains the same when its digits are
 reversed. For example, `121` is a palindromic number but `112` is not.
 

--- a/exercises/parallel-letter-frequency/description.md
+++ b/exercises/parallel-letter-frequency/description.md
@@ -1,3 +1,5 @@
+Count the frequency of letters in texts using parallel computation.
+
 Parallelism is about doing things in parallel that can also be done
 sequentially. A common example is counting the frequency of letters.
 Create a function that returns the total frequency of each letter in a

--- a/exercises/pascals-triangle/description.md
+++ b/exercises/pascals-triangle/description.md
@@ -1,3 +1,5 @@
+Compute Pascal's triangle up to a given number of rows.
+
 In Pascal's Triangle each number is computed by adding the numbers to
 the right and left of the current position in the previous row.
 

--- a/exercises/perfect-numbers/description.md
+++ b/exercises/perfect-numbers/description.md
@@ -1,3 +1,5 @@
+Determine if a number is perfect, abundant, or deficient based on Nicomachus' (60 - 120 CE) classification scheme for natural numbers.
+
 The Greek mathematician [Nicomachus](https://en.wikipedia.org/wiki/Nicomachus) devised a classification scheme for natural numbers, identifying each as belonging uniquely to the categories of **perfect**, **abundant**, or **deficient** based on their [aliquot sum](https://en.wikipedia.org/wiki/Aliquot_sum). The aliquot sum is defined as the sum of the factors of a number not including the number itself. For example, the aliquot sum of 15 is (1 + 3 + 5) = 9
 
 - **Perfect**: aliquot sum = number 

--- a/exercises/phone-number/description.md
+++ b/exercises/phone-number/description.md
@@ -1,3 +1,5 @@
+Clean up user-entered phone numbers so that they can be sent SMS messages.
+
 The **North American Numbering Plan (NANP)** is a telephone numbering system used by many countries in North America like the United States, Canada or Bermuda. All NANP-countries share the same international country code `1`.
 
 NANP numbers are ten-digit numbers consisting of a three-digit Numbering Plan Area code, commonly known as *area code*, followed by a seven-digit local number. The first three digits of the local number represent the *exchange code*, followed by the unique four-digit number which is the *subscriber number*.

--- a/exercises/pig-latin/description.md
+++ b/exercises/pig-latin/description.md
@@ -1,3 +1,5 @@
+Implement a program that translates from English to Pig Latin
+
 Pig Latin is a made-up children's language that's intended to be
 confusing. It obeys a few simple rules (below), but when it's spoken
 quickly it's really difficult for non-children (and non-native speakers)

--- a/exercises/point-mutations/description.md
+++ b/exercises/point-mutations/description.md
@@ -1,3 +1,5 @@
+Calculate the Hamming difference between two DNA strands.
+
 A mutation is simply a mistake that occurs during the creation or
 copying of a nucleic acid, in particular DNA. Because nucleic acids are
 vital to cellular functions, mutations tend to cause a ripple effect

--- a/exercises/poker/description.md
+++ b/exercises/poker/description.md
@@ -1,3 +1,5 @@
+Pick the best hand(s) from a list of poker hands.
+
 Write an algorithm to pick the best poker hand(s) from a list.
 
 See [wikipedia](https://en.wikipedia.org/wiki/List_of_poker_hands) for an

--- a/exercises/pov/description.md
+++ b/exercises/pov/description.md
@@ -1,3 +1,5 @@
+Reparent a graph on a selected node
+
 # Tree Reparenting
 
 This exercise is all about re-orientating a graph to see things from a different

--- a/exercises/prime-factors/description.md
+++ b/exercises/prime-factors/description.md
@@ -1,3 +1,5 @@
+Compute the prime factors of a given natural number.
+
 A prime number is only evenly divisible by itself and 1.
 
 Note that 1 is not a prime number.

--- a/exercises/protein-translation/description.md
+++ b/exercises/protein-translation/description.md
@@ -1,3 +1,5 @@
+Translate RNA sequences into proteins.
+
 Let's translate RNA sequences into proteins. [general ref](http://en.wikipedia.org/wiki/Translation_(biology))
 
 RNA can be broken into three nucleotide sequences called codons, and then translated to a polypeptide like so:

--- a/exercises/proverb/description.md
+++ b/exercises/proverb/description.md
@@ -1,3 +1,5 @@
+For want of a horseshoe nail, a kingdom was lost, or so the saying goes. Output the full text of this proverbial rhyme.
+
 For want of a nail the shoe was lost.
 For want of a shoe the horse was lost.
 For want of a horse the rider was lost.

--- a/exercises/pythagorean-triplet/description.md
+++ b/exercises/pythagorean-triplet/description.md
@@ -1,3 +1,5 @@
+There exists exactly one Pythagorean triplet for which a + b + c = 1000. Find the product a * b * c.
+
 A Pythagorean triplet is a set of three natural numbers, {a, b, c}, for
 which,
 

--- a/exercises/queen-attack/description.md
+++ b/exercises/queen-attack/description.md
@@ -1,3 +1,5 @@
+Given the position of two queens on a chess board, indicate whether or not they are positioned so that they can attack each other.
+
 In the game of chess, a queen can attack pieces which are on the same
 row, column, or diagonal.
 

--- a/exercises/rail-fence-cipher/description.md
+++ b/exercises/rail-fence-cipher/description.md
@@ -1,3 +1,5 @@
+Implement encoding and decoding for the rail fence cipher.
+
 The Rail Fence cipher is a form of transposition cipher that gets its name from
 the way in which it's encoded. It was already used by the ancient Greeks.
 

--- a/exercises/raindrops/description.md
+++ b/exercises/raindrops/description.md
@@ -1,3 +1,5 @@
+Convert a number to a string, the contents of which depend on the number's factors.
+
 - If the number has 3 as a factor, output 'Pling'.
 - If the number has 5 as a factor, output 'Plang'.
 - If the number has 7 as a factor, output 'Plong'.

--- a/exercises/react/description.md
+++ b/exercises/react/description.md
@@ -1,3 +1,5 @@
+Implement a basic reactive system.
+
 Reactive programming is a programming paradigm that focuses on how values
 are computed in terms of each other to allow a change to one value to
 automatically propagate to other values, like in a spreadsheet.

--- a/exercises/rectangles/description.md
+++ b/exercises/rectangles/description.md
@@ -1,3 +1,5 @@
+Count the rectangles in an ASCII diagram.
+
 Create a program to count the rectangles in an ASCII diagram like the one below.
 
 ```

--- a/exercises/rna-transcription/description.md
+++ b/exercises/rna-transcription/description.md
@@ -1,3 +1,5 @@
+Given a DNA strand, return its RNA complement (per RNA transcription).
+
 Both DNA and RNA strands are a sequence of nucleotides.
 
 The four nucleotides found in DNA are adenine (**A**), cytosine (**C**),

--- a/exercises/robot-name/description.md
+++ b/exercises/robot-name/description.md
@@ -1,3 +1,5 @@
+Manage robot factory settings.
+
 When robots come off the factory floor, they have no name.
 
 The first time you boot them up, a random name is generated in the format

--- a/exercises/robot-simulator/description.md
+++ b/exercises/robot-simulator/description.md
@@ -1,3 +1,5 @@
+Write a robot simulator.
+
 A robot factory's test facility needs a program to verify robot movements.
 
 The robots have three possible movements:

--- a/exercises/roman-numerals/description.md
+++ b/exercises/roman-numerals/description.md
@@ -1,3 +1,5 @@
+Write a function to convert from normal numbers to Roman Numerals.
+
 The Romans were a clever bunch. They conquered most of Europe and ruled
 it for hundreds of years. They invented concrete and straight roads and
 even bikinis. One thing they never discovered though was the number

--- a/exercises/rotational-cipher/description.md
+++ b/exercises/rotational-cipher/description.md
@@ -1,3 +1,5 @@
+Create an implementation of the rotational cipher, also sometimes called the Caesar cipher.
+
 # Rotational Cipher
 
 Create an implementation of the rotational cipher, also sometimes called the Caesar cipher.

--- a/exercises/run-length-encoding/description.md
+++ b/exercises/run-length-encoding/description.md
@@ -1,3 +1,5 @@
+Implement run-length encoding and decoding.
+
 Run-length encoding (RLE) is a simple form of data compression, where runs
 (consecutive data elements) are replaced by just one data value and count.
 

--- a/exercises/saddle-points/description.md
+++ b/exercises/saddle-points/description.md
@@ -1,3 +1,5 @@
+Detect saddle points in a matrix.
+
 So say you have a matrix like so:
 
 ```plain

--- a/exercises/say/description.md
+++ b/exercises/say/description.md
@@ -1,3 +1,5 @@
+Given a number from 0 to 999,999,999,999, spell out that number in English.
+
 ## Step 1
 
 Handle the basic case of 0 through 99.

--- a/exercises/scale-generator/description.md
+++ b/exercises/scale-generator/description.md
@@ -1,3 +1,5 @@
+Generate musical scales, given a starting note and a set of intervals. 
+
 Given a tonic, or starting note, and a set of intervals, generate
 the musical scale starting with the tonic and following the
 specified interval pattern.

--- a/exercises/scrabble-score/description.md
+++ b/exercises/scrabble-score/description.md
@@ -1,3 +1,5 @@
+Given a word, compute the scrabble score for that word.
+
 ## Letter Values
 
 You'll need these:

--- a/exercises/secret-handshake/description.md
+++ b/exercises/secret-handshake/description.md
@@ -1,3 +1,5 @@
+Given a decimal number, convert it to the appropriate sequence of events for a secret handshake.
+
 > There are 10 types of people in the world: Those who understand
 > binary, and those who don't.
 

--- a/exercises/series/description.md
+++ b/exercises/series/description.md
@@ -1,3 +1,5 @@
+Given a string of digits, output all the contiguous substrings of length `n` in that string.
+
 For example, the string "49142" has the following 3-digit series:
 
 - 491

--- a/exercises/sgf-parsing/description.md
+++ b/exercises/sgf-parsing/description.md
@@ -1,3 +1,5 @@
+Parsing a Smart Game Format string.
+
 [SGF](https://en.wikipedia.org/wiki/Smart_Game_Format) is a standard format for
 storing board game files, in particular go.
 

--- a/exercises/sieve/description.md
+++ b/exercises/sieve/description.md
@@ -1,3 +1,5 @@
+Use the Sieve of Eratosthenes to find all the primes from 2 up to a given number.
+
 The Sieve of Eratosthenes is a simple, ancient algorithm for finding all
 prime numbers up to any given limit. It does so by iteratively marking as
 composite (i.e. not prime) the multiples of each prime,

--- a/exercises/simple-cipher/description.md
+++ b/exercises/simple-cipher/description.md
@@ -1,3 +1,5 @@
+Implement a simple shift cipher like Caesar and a more secure substitution cipher
+
 ## Step 1
 
 "If he had anything confidential to say, he wrote it in cipher, that is,

--- a/exercises/simple-linked-list/description.md
+++ b/exercises/simple-linked-list/description.md
@@ -1,3 +1,5 @@
+Write a simple linked list implementation that uses Elements and a List
+
 The linked list is a fundamental data structure in computer science,
 often used in the implementation of other data structures. They're
 pervasive in functional programming languages, such as Clojure, Erlang,

--- a/exercises/space-age/description.md
+++ b/exercises/space-age/description.md
@@ -1,3 +1,5 @@
+Given an age in seconds, calculate how old someone is in terms of a given planet's solar years.
+
 Given an age in seconds, calculate how old someone would be on:
 
    - Earth: orbital period 365.25 Earth days, or 31557600 seconds

--- a/exercises/strain/description.md
+++ b/exercises/strain/description.md
@@ -1,3 +1,5 @@
+Implement the `keep` and `discard` operation on collections. Given a collection and a predicate on the collection's elements, `keep` returns a new collection containing those elements where the predicate is true, while `discard` returns a new collection containing those elements where the predicate is false.
+
 Write two functions that each take a function and a list.  One of them will
 return the list of items for which the passed in function is true, and the
 other will return the items for which it is false.

--- a/exercises/sublist/description.md
+++ b/exercises/sublist/description.md
@@ -1,3 +1,5 @@
+Write a function to determine if a list is a sublist of another list.
+
 Write a function that given two lists determines if the first list is
 contained within the second list, if the second list is contained within
 the first list, if both lists are contained within each other or if none

--- a/exercises/sum-of-multiples/description.md
+++ b/exercises/sum-of-multiples/description.md
@@ -1,3 +1,5 @@
+Given a number, find the sum of all the multiples of particular numbers up to but not including that number.
+
 If we list all the natural numbers up to but not including 20 that are
 multiples of either 3 or 5, we get 3, 5, 6 and 9, 10, 12, 15, and 18.
 

--- a/exercises/transpose/description.md
+++ b/exercises/transpose/description.md
@@ -1,3 +1,5 @@
+Take input text and output it transposed.
+
 Given an input text output it transposed.
 
 Roughly explained, the transpose of a matrix:

--- a/exercises/tree-building/description.md
+++ b/exercises/tree-building/description.md
@@ -1,3 +1,5 @@
+Refactor a tree building algorithm.
+
 Some web-forums have a tree layout, so posts are presented as a tree. However
 the posts are typically stored in a database as an unsorted set of records. Thus
 when presenting the posts to the user the tree structure has to be

--- a/exercises/triangle/description.md
+++ b/exercises/triangle/description.md
@@ -1,3 +1,5 @@
+Determine if a triangle is equilateral, isosceles, or scalene.
+
 An _equilateral_ triangle has all three sides the same length.<br/>
 An _isosceles_ triangle has at least two sides the same length. (It is sometimes
 specified as having exactly two sides the same length, but for the purposes of

--- a/exercises/trinary/description.md
+++ b/exercises/trinary/description.md
@@ -1,3 +1,5 @@
+Convert a trinary number, represented as a string (e.g. '102012'), to its decimal equivalent using first principles.
+
 The program should consider strings specifying an invalid trinary as the
 value 0.
 

--- a/exercises/twelve-days/description.md
+++ b/exercises/twelve-days/description.md
@@ -1,3 +1,5 @@
+Output the lyrics to 'The Twelve Days of Christmas'
+
 ```ruby
 On the first day of Christmas my true love gave to me, a Partridge in a Pear Tree.
 

--- a/exercises/two-bucket/description.md
+++ b/exercises/two-bucket/description.md
@@ -1,3 +1,5 @@
+Given two buckets of different size, demonstrate how to measure an exact number of liters.
+
 Given two buckets of different size, demonstrate how to measure an exact number of liters by strategically transferring liters of fluid between the buckets.
 
 Since this mathematical problem is fairly subject to interpretation / individual approach, the tests have been written specifically to expect one overarching solution.

--- a/exercises/variable-length-quantity/description.md
+++ b/exercises/variable-length-quantity/description.md
@@ -1,3 +1,5 @@
+Implement variable length quantity encoding and decoding.
+
 The goal of this exercise is to implement [VLQ](https://en.wikipedia.org/wiki/Variable-length_quantity) encoding/decoding.
 
 In short, the goal of this encoding is to encode integer values in a way that would save bytes.

--- a/exercises/word-count/description.md
+++ b/exercises/word-count/description.md
@@ -1,3 +1,5 @@
+Given a phrase, count the occurrences of each word in that phrase.
+
 For example for the input `"olly olly in come free"`
 
 ```plain

--- a/exercises/word-search/description.md
+++ b/exercises/word-search/description.md
@@ -1,3 +1,5 @@
+Create a program to solve a word search puzzle.
+
 In word search puzzles you get a square of letters and have to find specific
 words in them.
 

--- a/exercises/wordy/description.md
+++ b/exercises/wordy/description.md
@@ -1,3 +1,5 @@
+Parse and evaluate simple math word problems returning the answer as an integer.
+
 
 ## Iteration 1 — Addition
 

--- a/exercises/zebra-puzzle/description.md
+++ b/exercises/zebra-puzzle/description.md
@@ -1,3 +1,5 @@
+Solve the zebra puzzle.
+
 1. There are five houses.
 2. The Englishman lives in the red house.
 3. The Spaniard owns the dog.

--- a/exercises/zipper/description.md
+++ b/exercises/zipper/description.md
@@ -1,3 +1,5 @@
+Creating a zipper for a binary tree.
+
 [Zippers](https://en.wikipedia.org/wiki/Zipper_%28data_structure%29) are
 a way purely functional of navigating within a data structure and
 manipulating it.  They essentially contain a data structure and a


### PR DESCRIPTION
Resolves: #767

The problem description given in description.md should be complete and self contained, and not require the addition of the blurb to make sense.

This patch prepends the blurb from the `metadata.yml` onto the `description.md` together with a newline, matching the format provided by trackler for the README.

Waiting on: Update to trackler so that readmes so that the blurb does not appear to appear twice.