### PR TITLE
Add a file to keep track of track maintainers.

### DIFF
--- a/TRACK_MAINTAINERS.md
+++ b/TRACK_MAINTAINERS.md
@@ -33,73 +33,69 @@ TODO
 ### Orphaned
 
 * Bash
+* Ceylon
 * CoffeeScript
+* ColdFusion
 * D
 * Groovy
+* Haxe
+* Idris
 * Kotlin
+* Nim
 * PL/SQL
+* Pascal
 * Perl 5
 * Pony
+* PowerShell
+* Purescript
 * R
 * Standard ML
+* TECO
+* Tcl
+* The Netwide Assembler
+* VB.NET
+* Vimscript
 
 ### Endangered
 
-* Lua
-* Lisp
-* Erlang
-* Go
-* Factor
-* Perl 6
-* PHP
 * C++
 * Elm
 * Emacs Lisp
+* Erlang
+* Factor
+* Go
+* Lisp
 * Lisp Flavored Erlang
+* Lua
 * MIPS Assembly
+* PHP
+* Perl 6
+* Prolog
 * Racket
 * Scheme
-* Prolog
 
 ### At Risk
 
-* Swift
-* Rust (but very active)
-* OCaml
-* JavaScript
-* ECMAScript
-* Python
-* Scala
-* F#
 * C#
 * Clojure
+* ECMAScript
+* F#
+* JavaScript
+* OCaml
 * Objective-C
+* Python
+* Rust
+* Scala
+* Swift
 
 ### Maintained
 
+* C
+* Crystal
+* Elixir
+* Haskell
+* Java
 * Ruby   
    Active: @kotp, @insti, @hilary, @tommyschaefer, @bmulvihill  
    Alumni: @kytrinyx, @bernardoamc, @Cohen-Carlisle  
 
-* C
-* Java
-* Crystal
-* Elixir
-* Haskell
-
-### Inactive Tracks
-
-There has not been enough activity to generate a heartbeat for the following tracks:
-
-* Ceylon
-* ColdFusion
-* Haxe
-* Idris
-* The Netwide Assembler
-* Nim
-* Pascal
-* PowerShell
-* Purescript
-* Tcl
-* TECO
-* VB.NET

--- a/TRACK_MAINTAINERS.md
+++ b/TRACK_MAINTAINERS.md
@@ -79,7 +79,7 @@ TODO
 
 * Ruby   
    Active: @kotp, @insti, @hilary, @tommyschaefer, @bmulvihill  
-   Alumni: @kytrynx, @bernardoamc, @Cohen-Carlisle  
+   Alumni: @kytrinyx, @bernardoamc, @Cohen-Carlisle  
 
 * C
 * Java

--- a/TRACK_MAINTAINERS.md
+++ b/TRACK_MAINTAINERS.md
@@ -1,8 +1,11 @@
-What this is about - TODO
+https://github.com/exercism/discussions/issues/97 investigated the status of all Exercism language tracks. This file is intended to continue and maintain that process in a community driven manner.
 
 Information about who is a maintainer can be found on the [Exercism Teams
 page](https://github.com/orgs/exercism/teams) but unhelpfully, you need to be a
 team member before you can see the other team members.
+
+Ideally a bot could keep this file updated, but until someone writes one we
+will just have to do it manually.
 
 
 See also: 

--- a/TRACK_MAINTAINERS.md
+++ b/TRACK_MAINTAINERS.md
@@ -5,7 +5,10 @@ page](https://github.com/orgs/exercism/teams) but unhelpfully, you need to be a
 team member before you can see the other team members.
 
 
-See also: https://github.com/exercism/discussions/issues/97
+See also: 
+
+* https://github.com/exercism/discussions/issues/97
+* http://tinyletter.com/exercism/letters/exercism-behind-the-scenes-the-challenge-of-unmaintained-and-undermaintained-tracks
 
 
 # Instructions

--- a/TRACK_MAINTAINERS.md
+++ b/TRACK_MAINTAINERS.md
@@ -95,7 +95,7 @@ TODO
 * Elixir
 * Haskell
 * Java
-* [Ruby](https://github.com/exercism/xruby)
+* [Ruby](https://github.com/exercism/xruby)  
    Active: kotp, insti, hilary, tommyschaefer, bmulvihill  
    Alumni: kytrinyx, bernardoamc, Cohen-Carlisle  
 

--- a/TRACK_MAINTAINERS.md
+++ b/TRACK_MAINTAINERS.md
@@ -95,7 +95,7 @@ TODO
 * Elixir
 * Haskell
 * Java
-* Ruby   
-   Active: @kotp, @insti, @hilary, @tommyschaefer, @bmulvihill  
-   Alumni: @kytrinyx, @bernardoamc, @Cohen-Carlisle  
+* [Ruby](https://github.com/exercism/xruby)
+   Active: kotp, insti, hilary, tommyschaefer, bmulvihill  
+   Alumni: kytrinyx, bernardoamc, Cohen-Carlisle  
 

--- a/TRACK_MAINTAINERS.md
+++ b/TRACK_MAINTAINERS.md
@@ -1,0 +1,102 @@
+What this is about - TODO
+
+Information about who is a maintainer can be found on the [Exercism Teams
+page](https://github.com/orgs/exercism/teams) but unhelpfully, you need to be a
+team member before you can see the other team members.
+
+
+See also: https://github.com/exercism/discussions/issues/97
+
+
+# Instructions
+
+Sumbit a PR to this file add/remove maintainers.
+
+# Becoming a maintainer
+
+TODO
+
+# Stepping down as a matntainer
+
+TODO
+
+# Status
+
+ * ORPHANED - Nobody has merged anything in the past year.
+ * ENDANGERED - Somewhere between ORPHANED and AT RISK.
+ * AT RISK - Two people are actively discussing issues and reviewing and merging pull requests.
+ * MAINTAINED - Three or more people are actively discussing issues and reviewing and merging pull requests.
+
+### Orphaned
+
+* Bash
+* CoffeeScript
+* D
+* Groovy
+* Kotlin
+* PL/SQL
+* Perl 5
+* Pony
+* R
+* Standard ML
+
+### Endangered
+
+* Lua
+* Lisp
+* Erlang
+* Go
+* Factor
+* Perl 6
+* PHP
+* C++
+* Elm
+* Emacs Lisp
+* Lisp Flavored Erlang
+* MIPS Assembly
+* Racket
+* Scheme
+* Prolog
+
+### At Risk
+
+* Swift
+* Rust (but very active)
+* OCaml
+* JavaScript
+* ECMAScript
+* Python
+* Scala
+* F#
+* C#
+* Clojure
+* Objective-C
+
+### Maintained
+
+* Ruby   
+   Active: @kotp, @insti, @hilary, @tommyschaefer, @bmulvihill  
+   Alumni: @kytrynx, @bernardoamc, @Cohen-Carlisle  
+
+* C
+* Java
+* Crystal
+* Elixir
+* Haskell
+
+### Inactive Tracks
+
+There has not been enough activity to generate a heartbeat for the following tracks:
+
+* Ceylon
+* ColdFusion
+* Haxe
+* Idris
+* The Netwide Assembler
+* Nim
+* Pascal
+* PowerShell
+* Purescript
+* Tcl
+* TECO
+* VB.NET


### PR DESCRIPTION
https://github.com/exercism/discussions/issues/97 investigated the status of all Exercism language tracks. This file is intended to continue and maintain that process in a community driven manner.

My intention is for this version to be merged and then further PR's can fill out/update the rest of the information.

See "Ruby" under the "Maintained" section for an example of what information I think there should be for each track.

Ideally a bot could keep it updated, but until someone writes one we will just have to do it manually.

