### PR TITLE
acronym: remove test case with mixed-case phrase

### DIFF
--- a/exercises/acronym/canonical-data.json
+++ b/exercises/acronym/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "acronym",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "cases": [
     {
       "description": "Abbreviate a phrase",
@@ -16,12 +16,6 @@
           "property": "abbreviate",
           "phrase": "Ruby on Rails",
           "expected": "ROR"
-        },
-        {
-          "description": "camelcase",
-          "property": "abbreviate",
-          "phrase": "HyperText Markup Language",
-          "expected": "HTML"
         },
         {
           "description": "punctuation",


### PR DESCRIPTION
Closes #787.

Remove the `HyperText Markup Language` test case from `acronym` so that there are no mixed-case (camel-case) test cases in this exercise.

Version number of test suite bumped to 1.1.0.