### PR TITLE
difference-of-squares: add tests for boundary cases

### DIFF
--- a/exercises/difference-of-squares/canonical-data.json
+++ b/exercises/difference-of-squares/canonical-data.json
@@ -1,21 +1,27 @@
 {
   "exercise": "difference-of-squares",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "cases": [
     {
       "description": "Square the sum of the numbers up to the given number",
       "cases": [
         {
+          "description": "square of sum 0",
+          "property": "squareOfSum",
+          "number": 0,
+          "expected": 0
+        },
+        {
+          "description": "square of sum 1",
+          "property": "squareOfSum",
+          "number": 1,
+          "expected": 1
+        },
+        {
           "description": "square of sum 5",
           "property": "squareOfSum",
           "number": 5,
           "expected": 225
-        },
-        {
-          "description": "square of sum 10",
-          "property": "squareOfSum",
-          "number": 10,
-          "expected": 3025
         },
         {
           "description": "square of sum 100",
@@ -29,16 +35,22 @@
       "description": "Sum the squares of the numbers up to the given number",
       "cases": [
         {
+          "description": "sum of squares 0",
+          "property": "sumOfSquares",
+          "number": 0,
+          "expected": 0
+        },
+        {
+          "description": "sum of squares 1",
+          "property": "sumOfSquares",
+          "number": 1,
+          "expected": 1
+        },
+        {
           "description": "sum of squares 5",
           "property": "sumOfSquares",
           "number": 5,
           "expected": 55
-        },
-        {
-          "description": "sum of squares 10",
-          "property": "sumOfSquares",
-          "number": 10,
-          "expected": 385
         },
         {
           "description": "sum of squares 100",
@@ -58,16 +70,16 @@
           "expected": 0
         },
         {
+          "description": "difference of squares 1",
+          "property": "differenceOfSquares",
+          "number": 1,
+          "expected": 0
+        },
+        {
           "description": "difference of squares 5",
           "property": "differenceOfSquares",
           "number": 5,
           "expected": 170
-        },
-        {
-          "description": "difference of squares 10",
-          "property": "differenceOfSquares",
-          "number": 10,
-          "expected": 2640
         },
         {
           "description": "difference of squares 100",

--- a/exercises/difference-of-squares/canonical-data.json
+++ b/exercises/difference-of-squares/canonical-data.json
@@ -6,18 +6,6 @@
       "description": "Square the sum of the numbers up to the given number",
       "cases": [
         {
-          "description": "square of sum 0",
-          "property": "squareOfSum",
-          "number": 0,
-          "expected": 0
-        },
-        {
-          "description": "square of sum 1",
-          "property": "squareOfSum",
-          "number": 1,
-          "expected": 1
-        },
-        {
           "description": "square of sum 5",
           "property": "squareOfSum",
           "number": 5,
@@ -28,24 +16,18 @@
           "property": "squareOfSum",
           "number": 100,
           "expected": 25502500
+        },
+        {
+          "description": "square of sum 1",
+          "property": "squareOfSum",
+          "number": 1,
+          "expected": 1
         }
       ]
     },
     {
       "description": "Sum the squares of the numbers up to the given number",
       "cases": [
-        {
-          "description": "sum of squares 0",
-          "property": "sumOfSquares",
-          "number": 0,
-          "expected": 0
-        },
-        {
-          "description": "sum of squares 1",
-          "property": "sumOfSquares",
-          "number": 1,
-          "expected": 1
-        },
         {
           "description": "sum of squares 5",
           "property": "sumOfSquares",
@@ -57,24 +39,18 @@
           "property": "sumOfSquares",
           "number": 100,
           "expected": 338350
+        },
+        {
+          "description": "sum of squares 1",
+          "property": "sumOfSquares",
+          "number": 1,
+          "expected": 1
         }
       ]
     },
     {
       "description": "Subtract sum of squares from square of sums",
       "cases": [
-        {
-          "description": "difference of squares 0",
-          "property": "differenceOfSquares",
-          "number": 0,
-          "expected": 0
-        },
-        {
-          "description": "difference of squares 1",
-          "property": "differenceOfSquares",
-          "number": 1,
-          "expected": 0
-        },
         {
           "description": "difference of squares 5",
           "property": "differenceOfSquares",
@@ -86,6 +62,12 @@
           "property": "differenceOfSquares",
           "number": 100,
           "expected": 25164150
+        },
+        {
+          "description": "difference of squares 1",
+          "property": "differenceOfSquares",
+          "number": 1,
+          "expected": 0
         }
       ]
     }

--- a/exercises/difference-of-squares/canonical-data.json
+++ b/exercises/difference-of-squares/canonical-data.json
@@ -6,6 +6,12 @@
       "description": "Square the sum of the numbers up to the given number",
       "cases": [
         {
+          "description": "square of sum 1",
+          "property": "squareOfSum",
+          "number": 1,
+          "expected": 1
+        },
+        {
           "description": "square of sum 5",
           "property": "squareOfSum",
           "number": 5,
@@ -16,18 +22,18 @@
           "property": "squareOfSum",
           "number": 100,
           "expected": 25502500
-        },
-        {
-          "description": "square of sum 1",
-          "property": "squareOfSum",
-          "number": 1,
-          "expected": 1
         }
       ]
     },
     {
       "description": "Sum the squares of the numbers up to the given number",
       "cases": [
+        {
+          "description": "sum of squares 1",
+          "property": "sumOfSquares",
+          "number": 1,
+          "expected": 1
+        },
         {
           "description": "sum of squares 5",
           "property": "sumOfSquares",
@@ -39,18 +45,18 @@
           "property": "sumOfSquares",
           "number": 100,
           "expected": 338350
-        },
-        {
-          "description": "sum of squares 1",
-          "property": "sumOfSquares",
-          "number": 1,
-          "expected": 1
         }
       ]
     },
     {
       "description": "Subtract sum of squares from square of sums",
       "cases": [
+        {
+          "description": "difference of squares 1",
+          "property": "differenceOfSquares",
+          "number": 1,
+          "expected": 0
+        },
         {
           "description": "difference of squares 5",
           "property": "differenceOfSquares",
@@ -62,12 +68,6 @@
           "property": "differenceOfSquares",
           "number": 100,
           "expected": 25164150
-        },
-        {
-          "description": "difference of squares 1",
-          "property": "differenceOfSquares",
-          "number": 1,
-          "expected": 0
         }
       ]
     }


### PR DESCRIPTION
See #789.

Zero is by some definitions regarded as a natural number, so an implementation should be able to handle this case, as well as the edge case of 1.

Summary of changes:

- Add tests for edge cases 0 and 1
- Remove test for input 10 (there are tests for 5 and 100 and if the implementation works for these numbers, it most likely also works for 10)
- Bump version number of the test suite to 1.1.0

I think the [description](https://github.com/exercism/x-common/blob/master/exercises/difference-of-squares/description.md) is ok, no need to include 0 there as it has anyway no influence on the result.