### PR TITLE
secret-handshake: remove tests for numbers > 31

### DIFF
--- a/exercises/secret-handshake/canonical-data.json
+++ b/exercises/secret-handshake/canonical-data.json
@@ -1,6 +1,19 @@
 {
   "exercise": "secret-handshake",
-  "version": "1.0.0",
+  "version": "1.1.0",
+  "comments": [
+    " In a discussion in https://github.com/exercism/x-common/pull/794 and    ",
+    " https://github.com/exercism/x-common/issues/335 it has been decided to  ",
+    " only include numbers between 0 and 31 (00000 to 11111) in the canonical ",
+    " test data.                                                              ",
+    "                                                                         ",
+    " This is to allow for different implementations in different tracks and  ",
+    " not restrict solutions to bitwise or modulo-based algorithms.           ",
+    "                                                                         ",
+    " Tracks may include additional tests for numbers > 31 in their test      ",
+    " suites. In this case, 32 (100000) should yield the same result as 0,    ",
+    " 33 (100001) should yield the same result as 1, and so on.               "
+  ],
   "cases": [
     {
       "description": "Create a handshake for a number",
@@ -69,12 +82,6 @@
           "description": "do nothing for zero",
           "property": "commands",
           "input": 0,
-          "expected": []
-        },
-        {
-          "description": "do nothing if lower 5 bits not set",
-          "property": "commands",
-          "input": 32,
           "expected": []
         }
       ]


### PR DESCRIPTION
I saw a solution which just returned an empty list for all numbers >= 32. This is obviously wrong, as the 5 least significant bits should define the sequence of signals, no matter how large the number is. However, the current test suite tests only 32, and so all the tests passed for this solution.

I added therefore a couple of test cases for numbers > 32.

Not sure if the problem description should also be updated to make this clearer.