### PR TITLE
update contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ themselves. There are other guides about contributing to other parts of the Exer
 * [Maintaining a Track](#maintaining-a-track)
 * [Useful Tidbits](#useful-tidbits)
     * [Pull Request Guidelines](#pull-request-guidelines)
-    * [Exercise Versioning](#exercise-versioning)
+    * [Exercise Versioning](https://github.com/exercism/docs/blob/master/maintaining-a-track/exercise-versioning.md)
     * [Anatomy of an Exercise](#anatomy-of-an-exercise)
     * [Track configuration file (config.json)](#track-configuration-file)
     * [Track-Level Linting With Configlet](#track-level-linting-with-configlet)
@@ -159,7 +159,7 @@ If you're unsure where to make the change, ask us, and we'll help you figure it 
 Once you've updated the test suite, there are a few things you'll want to check.
 
 - Make sure the [reference solution](#reference-solution) is still passing.
-- If the exercise is [versioned](#exercise-versioning), and the change will
+- If the exercise is [versioned](https://github.com/exercism/docs/blob/master/maintaining-a-track/exercise-versioning.md), and the change will
   mean that existing solutions on the site will not pass the new tests, then
   increment the version number, both in the test and in the reference solution.
 - Run the full, track-level test suite, if available.
@@ -617,30 +617,6 @@ will review it. Some tracks are less active and might not have someone
 checking in every day. If you don't get a response within a couple of days,
 feel free to ping us in the [support
 chat](https://gitter.im/exercism/support).
-
-### Exercise Versioning
-
-It's only when we get a bunch of people having conversations about the
-solutions that we really discover what makes a problem interesting, and
-in what way it can be improved.
-
-Some changes to the test suites will invalidate existing solutions that people
-have submitted.
-
-We think this is totally fine, however sometimes people start leaving feedback
-saying _this doesn't pass the tests_. This is technically true, but since the
-solution passed the tests at the time it was written, it's generally more
-useful to just discuss the code as it is, rather than enforce strict
-adherence to the most recent version of the tests.
-
-Some language tracks have implemented a simple, manual versioning system to
-help avoid unnecessary discussions about failing the current test suites.
-
-If the exercise is versioned, then the test suite will probably have a
-_book-keeping_ type test at the very bottom that asserts against a value in
-the reference solution. If the change you're making is backwards-incompatible,
-then please increment the version in both the test suite and the reference
-solution.
 
 ### Anatomy of an Exercise
 


### PR DESCRIPTION
Removed copy from contributing.md explaining exercise versioning and moved to its own file in https://github.com/exercism/docs/blob/master/maintaining-a-track/ , edited links referencing anchors to now reference the new file that is to be created in pull request.