### PR TITLE
Add period to end of first description line.

### DIFF
--- a/exercises/acronym/description.md
+++ b/exercises/acronym/description.md
@@ -1,4 +1,4 @@
-Convert a long phrase to its acronym
+Convert a long phrase to its acronym.
 
 Techies love their TLA (Three Letter Acronyms)!
 

--- a/exercises/binary/description.md
+++ b/exercises/binary/description.md
@@ -1,4 +1,4 @@
-Convert a binary number, represented as a string (e.g. '101010'), to its decimal equivalent using first principles
+Convert a binary number, represented as a string (e.g. '101010'), to its decimal equivalent using first principles.
 
 Implement binary to decimal conversion. Given a binary input
 string, your program should produce a decimal output. The

--- a/exercises/bowling/description.md
+++ b/exercises/bowling/description.md
@@ -1,4 +1,4 @@
-Score a bowling game
+Score a bowling game.
 
 Bowling is game where players roll a heavy ball to knock down pins
 arranged in a triangle. Write code to keep track of the score

--- a/exercises/change/description.md
+++ b/exercises/change/description.md
@@ -1,4 +1,4 @@
-Correctly determine change to be given using the least number of coins
+Correctly determine change to be given using the least number of coins.
 
 Correctly determine the fewest number of coins to be given to the user
 such that the sum of the coins' value would equal the correct amount

--- a/exercises/connect/description.md
+++ b/exercises/connect/description.md
@@ -1,4 +1,4 @@
-Compute the result for a game of Hex / Polygon
+Compute the result for a game of Hex / Polygon.
 
 The abstract boardgame known as
 [Hex](https://en.wikipedia.org/wiki/Hex_%28board_game%29) / Polygon /

--- a/exercises/dot-dsl/description.md
+++ b/exercises/dot-dsl/description.md
@@ -1,4 +1,4 @@
-Write a Domain Specific Language similar to the Graphviz dot language
+Write a Domain Specific Language similar to the Graphviz dot language.
 
 A [Domain Specific Language
 (DSL)](https://en.wikipedia.org/wiki/Domain-specific_language) is a

--- a/exercises/error-handling/description.md
+++ b/exercises/error-handling/description.md
@@ -1,4 +1,4 @@
-Implement various kinds of error handling and resource management
+Implement various kinds of error handling and resource management.
 
 An important point of programming is how to handle errors and close
 resources even if errors occur.

--- a/exercises/flatten-array/description.md
+++ b/exercises/flatten-array/description.md
@@ -1,4 +1,4 @@
-Take a nested list and return a single list with all values except nil/null
+Take a nested list and return a single list with all values except nil/null.
 
 The challenge is to write a function that accepts an arbitrarily-deep nested list-like structure and returns a flattened structure without any nil/null values.
  

--- a/exercises/food-chain/description.md
+++ b/exercises/food-chain/description.md
@@ -1,4 +1,4 @@
-Generate the lyrics of the song 'I Know an Old Lady Who Swallowed a Fly'
+Generate the lyrics of the song 'I Know an Old Lady Who Swallowed a Fly'.
 
 While you could copy/paste the lyrics,
 or read them from a file, this problem is much more

--- a/exercises/forth/description.md
+++ b/exercises/forth/description.md
@@ -1,4 +1,4 @@
-Implement an evaluator for a very simple subset of Forth
+Implement an evaluator for a very simple subset of Forth.
 
 [Forth](https://en.wikipedia.org/wiki/Forth_%28programming_language%29)
 is a stack-based programming language. Implement a very basic evaluator

--- a/exercises/grade-school/description.md
+++ b/exercises/grade-school/description.md
@@ -1,4 +1,4 @@
-Given students' names along with the grade that they are in, create a roster for the school
+Given students' names along with the grade that they are in, create a roster for the school.
 
 In the end, you should be able to:
 

--- a/exercises/hello-world/description.md
+++ b/exercises/hello-world/description.md
@@ -1,4 +1,4 @@
-The classical introductory exercise. Just say "Hello, World!"
+The classical introductory exercise. Just say "Hello, World!".
 
 ["Hello, World!"](http://en.wikipedia.org/wiki/%22Hello,_world!%22_program) is
 the traditional first program for beginning programming in a new language

--- a/exercises/linked-list/description.md
+++ b/exercises/linked-list/description.md
@@ -1,4 +1,4 @@
-Implement a doubly linked list
+Implement a doubly linked list.
 
 Like an array, a linked list is a simple linear data structure. Several 
 common data types can be implemented using linked lists, like queues, 

--- a/exercises/list-ops/description.md
+++ b/exercises/list-ops/description.md
@@ -1,4 +1,4 @@
-Implement basic list operations
+Implement basic list operations.
 
 In functional languages list operations like `length`, `map`, and
 `reduce` are very common. Implement a series of basic list operations,

--- a/exercises/markdown/description.md
+++ b/exercises/markdown/description.md
@@ -1,4 +1,4 @@
-Refactor a Markdown parser
+Refactor a Markdown parser.
 
 The markdown exercise is a refactoring exercise. There is code that parses a
 given string with [Markdown

--- a/exercises/minesweeper/description.md
+++ b/exercises/minesweeper/description.md
@@ -1,4 +1,4 @@
-Add the numbers to a minesweeper board
+Add the numbers to a minesweeper board.
 
 Minesweeper is a popular game where the user has to find the mines using
 numeric hints that indicate how many mines are directly adjacent

--- a/exercises/paasio/description.md
+++ b/exercises/paasio/description.md
@@ -1,4 +1,4 @@
-Report network IO statistics
+Report network IO statistics.
 
 You are writing a [PaaS][], and you need a way to bill customers based
 on network and filesystem usage.

--- a/exercises/pig-latin/description.md
+++ b/exercises/pig-latin/description.md
@@ -1,4 +1,4 @@
-Implement a program that translates from English to Pig Latin
+Implement a program that translates from English to Pig Latin.
 
 Pig Latin is a made-up children's language that's intended to be
 confusing. It obeys a few simple rules (below), but when it's spoken

--- a/exercises/pov/description.md
+++ b/exercises/pov/description.md
@@ -1,4 +1,4 @@
-Reparent a graph on a selected node
+Reparent a graph on a selected node.
 
 # Tree Reparenting
 

--- a/exercises/scale-generator/description.md
+++ b/exercises/scale-generator/description.md
@@ -1,4 +1,4 @@
-Generate musical scales, given a starting note and a set of intervals. 
+Generate musical scales, given a starting note and a set of intervals.
 
 Given a tonic, or starting note, and a set of intervals, generate
 the musical scale starting with the tonic and following the

--- a/exercises/simple-cipher/description.md
+++ b/exercises/simple-cipher/description.md
@@ -1,4 +1,4 @@
-Implement a simple shift cipher like Caesar and a more secure substitution cipher
+Implement a simple shift cipher like Caesar and a more secure substitution cipher.
 
 ## Step 1
 

--- a/exercises/simple-linked-list/description.md
+++ b/exercises/simple-linked-list/description.md
@@ -1,4 +1,4 @@
-Write a simple linked list implementation that uses Elements and a List
+Write a simple linked list implementation that uses Elements and a List.
 
 The linked list is a fundamental data structure in computer science,
 often used in the implementation of other data structures. They're

--- a/exercises/twelve-days/description.md
+++ b/exercises/twelve-days/description.md
@@ -1,4 +1,4 @@
-Output the lyrics to 'The Twelve Days of Christmas'
+Output the lyrics to 'The Twelve Days of Christmas'.
 
 ```ruby
 On the first day of Christmas my true love gave to me, a Partridge in a Pear Tree.


### PR DESCRIPTION
In #775 the first line of the description (which is/was the blurb.) was sometimes missing a
period.

This PR adds periods in the appropriate places.

This no longer exactly matches the output of the old readme, but makes the
description more grammatically correct.