### PR TITLE
proverb: fix description formatting

### DIFF
--- a/exercises/proverb/description.md
+++ b/exercises/proverb/description.md
@@ -1,10 +1,10 @@
 For want of a horseshoe nail, a kingdom was lost, or so the saying goes. Output
-the full text of this proverbial rhyme.
+the full text of this proverbial rhyme:
 
-For want of a nail the shoe was lost.
-For want of a shoe the horse was lost.
-For want of a horse the rider was lost.
-For want of a rider the message was lost.
-For want of a message the battle was lost.
-For want of a battle the kingdom was lost.
-And all for the want of a horseshoe nail.
+> For want of a nail the shoe was lost.  
+> For want of a shoe the horse was lost.  
+> For want of a horse the rider was lost.  
+> For want of a rider the message was lost.  
+> For want of a message the battle was lost.  
+> For want of a battle the kingdom was lost.  
+> And all for the want of a horseshoe nail.


### PR DESCRIPTION
Fixes proverb lines not rendering with newline separators; adds quote formatting to proverb.

<img width="949" alt="screen shot 2017-05-29 at 9 58 47 pm" src="https://cloud.githubusercontent.com/assets/6463980/26565534/03d2f7ae-44ba-11e7-8de2-488c2521591b.png">
