### PR TITLE
Moved track-level linting with configlet guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -692,19 +692,7 @@ Optional keys:
 * `solution_pattern` - A (case sensitive) regex pattern that matches solution files in the track repository. Used by [configlet](https://github.com/exercism/configlet) to check for the presence of an example solution for each problem implemented by the track.  The default value used if this key is not present is `[Ee]xample`.
 
 ### Track-Level Linting With Configlet
-
-If the `config.json` file is incomplete or broken, a lot of other things break.
-To make things easier we made a small tool to help verify the config:
-https://github.com/exercism/configlet#configlet
-
-You can download the latest release from the releases page in the [configlet
-repo](https://github.com/exercism/configlet/releases), or you can use the
-`bin/fetch-configlet` command from the root of the language track repository,
-which will make a guess at what operating system and architecture you have and
-attempt to download the right one.
-
-Verify the config by calling `bin/configlet .` (notice the dot). This says
-_check the config of the language track that is stored right here).
+Refer to [documentation](https://github.com/exercism/docs/tree/master/maintaining-a-track)
 
 ### Git Basics
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -691,9 +691,6 @@ Optional keys:
 * `ignore_pattern` - A (case insensitive) regex pattern that will cause files matching it to not be served to the student by `exercism fetch`. The default value used if this key is not present is `example`
 * `solution_pattern` - A (case sensitive) regex pattern that matches solution files in the track repository. Used by [configlet](https://github.com/exercism/configlet) to check for the presence of an example solution for each problem implemented by the track.  The default value used if this key is not present is `[Ee]xample`.
 
-### Track-Level Linting With Configlet
-Refer to [documentation](https://github.com/exercism/docs/tree/master/maintaining-a-track)
-
 ### Git Basics
 
 If you're concerned that you haven't done it right, don't worry. Submit your pull request, and we'll help you get the details sorted out.


### PR DESCRIPTION
Referencing issue [#27](https://github.com/exercism/docs/issues/27) in docs repo.

Hello. I deleted the track-level linting guidelines from CONTRIBUTING.md. However, this time, I did not remove the header and instead added a link to the [maintaining-a-track/](https://github.com/exercism/docs/tree/master/maintaining-a-track) directory in the docs repo as placeholder.