### PR TITLE
Update dominoes canonical-data expected key

### DIFF
--- a/exercises/dominoes/canonical-data.json
+++ b/exercises/dominoes/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "dominoes",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "comments": [
     "Inputs are given as lists of two-element lists.",
     "Feel free to convert the input to a sensible type in the specific language",
@@ -41,37 +41,37 @@
       "description": "empty input = empty output",
       "property": "canChain",
       "input": [],
-      "can_chain": true
+      "expected": true
     },
     {
       "description": "singleton input = singleton output",
       "property": "canChain",
       "input": [[1, 1]],
-      "can_chain": true
+      "expected": true
     },
     {
       "description": "singleton that can't be chained",
       "property": "canChain",
       "input": [[1, 2]],
-      "can_chain": false
+      "expected": false
     },
     {
       "description": "three elements",
       "property": "canChain",
       "input": [[1, 2], [3, 1], [2, 3]],
-      "can_chain": true
+      "expected": true
     },
     {
       "description": "can reverse dominoes",
       "property": "canChain",
       "input": [[1, 2], [1, 3], [2, 3]],
-      "can_chain": true
+      "expected": true
     },
     {
       "description": "can't be chained",
       "property": "canChain",
       "input": [[1, 2], [4, 1], [2, 3]],
-      "can_chain": false
+      "expected": false
     },
     {
       "description": "disconnected - simple",
@@ -84,19 +84,19 @@
       ],
       "property": "canChain",
       "input": [[1, 1], [2, 2]],
-      "can_chain": false
+      "expected": false
     },
     {
       "description": "disconnected - double loop",
       "property": "canChain",
       "input": [[1, 2], [2, 1], [3, 4], [4, 3]],
-      "can_chain": false
+      "expected": false
     },
     {
       "description": "disconnected - single isolated",
       "property": "canChain",
       "input": [[1, 2], [2, 3], [3, 1], [4, 4]],
-      "can_chain": false
+      "expected": false
     },
     {
       "description": "need backtrack",
@@ -109,19 +109,19 @@
       ],
       "property": "canChain",
       "input": [[1, 2], [2, 3], [3, 1], [2, 4], [2, 4]],
-      "can_chain": true
+      "expected": true
     },
     {
       "description": "separate loops",
       "property": "canChain",
       "input": [[1, 2], [2, 3], [3, 1], [1, 1], [2, 2], [3, 3]],
-      "can_chain": true
+      "expected": true
     },
     {
       "description": "nine elements",
       "property": "canChain",
       "input": [[1, 2], [5, 3], [3, 1], [1, 2], [2, 4], [1, 6], [2, 3], [3, 4], [5, 6]],
-      "can_chain": true
+      "expected": true
     }
   ]
 }


### PR DESCRIPTION
It was "can-chain", but most other exercises have "expected" as the expected output of a property being tested.