### PR TITLE
Remove "ruby" from fenced code block

### DIFF
--- a/exercises/twelve-days/description.md
+++ b/exercises/twelve-days/description.md
@@ -1,6 +1,6 @@
 Output the lyrics to 'The Twelve Days of Christmas'.
 
-```ruby
+```
 On the first day of Christmas my true love gave to me, a Partridge in a Pear Tree.
 
 On the second day of Christmas my true love gave to me, two Turtle Doves, and a Partridge in a Pear Tree.


### PR DESCRIPTION
The fenced code block does not contain Ruby.

Matters because some editors highlight the content of fenced code blocks, and you get `true`, `in`, and others colored.