### PR TITLE
all-your-base: update test case ordering

### DIFF
--- a/exercises/all-your-base/canonical-data.json
+++ b/exercises/all-your-base/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "all-your-base",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "comments": [
     "It's up to each track do decide:",
     "",
@@ -119,6 +119,30 @@
       "expected": null
     },
     {
+      "description": "first base is one",
+      "property": "rebase",
+      "input_base": 1,
+      "input_digits": [],
+      "output_base": 10,
+      "expected": null
+    },
+    {
+      "description": "first base is zero",
+      "property": "rebase",
+      "input_base": 0,
+      "input_digits": [],
+      "output_base": 10,
+      "expected": null
+    },
+    {
+      "description": "first base is negative",
+      "property": "rebase",
+      "input_base": -2,
+      "input_digits": [1],
+      "output_base": 10,
+      "expected": null
+    },
+    {
       "description": "negative digit",
       "property": "rebase",
       "input_base": 2,
@@ -135,14 +159,6 @@
       "expected": null
     },
     {
-      "description": "first base is one",
-      "property": "rebase",
-      "input_base": 1,
-      "input_digits": [],
-      "output_base": 10,
-      "expected": null
-    },
-    {
       "description": "second base is one",
       "property": "rebase",
       "input_base": 2,
@@ -151,27 +167,11 @@
       "expected": null
     },
     {
-      "description": "first base is zero",
-      "property": "rebase",
-      "input_base": 0,
-      "input_digits": [],
-      "output_base": 10,
-      "expected": null
-    },
-    {
       "description": "second base is zero",
       "property": "rebase",
       "input_base": 10,
       "input_digits": [7],
       "output_base": 0,
-      "expected": null
-    },
-    {
-      "description": "first base is negative",
-      "property": "rebase",
-      "input_base": -2,
-      "input_digits": [1],
-      "output_base": 10,
       "expected": null
     },
     {


### PR DESCRIPTION
Both [xjava](https://github.com/exercism/xjava/issues/519) and [xcsharp](https://github.com/exercism/xcsharp/pull/178#issuecomment-308018694) ran into issues regarding input validation for this exercise. In particular, when writing a test that verifies an initial base of 1 is invalid, it's unclear what the initial list of digits should be:

```
const int inputBase = 1;
var inputDigits = new[] {}; // inputDigits is also invalid; which error should we throw...?
```

```
const int inputBase = 1;
var inputDigits = new[] {0}; // an argument could be made for this combination being a valid representation of 0...
```

```
const int inputBase = 1;
var inputDigits = new[] {0, 1}; // inputDigits is also invalid; which error should we throw...?
```

This was exacerbated by the ordering of the current tests, which didn't validate inputs 'in order', if you consider that the natural order of inputs is probably as follows:

1. Initial base, since without this we cannot interpret the initial digits;
1. Initial digits, since we can't convert to an alternate representation without knowing the number we are initially representing;
1. Target base.

This PR updates the test ordering in the following ways:

- Tests that are left open to interpretation but that do not _necessarily_ represent invalid input (e.g. tests around representations of zero) are grouped together at the start of the tests that require interpretation
- Tests that actually check for invalid input are grouped by input and appear in the order of the inputs described above.

This means an implementor will be guided to write validation for the first input first, the second input second, etc., which then allows test writers to more safely make assumptions about which error messaging should be used in the case described at the beginning of this PR description.