### PR TITLE
rna-transcription: correct abbreviations in user-facing descriptions

### DIFF
--- a/exercises/rna-transcription/canonical-data.json
+++ b/exercises/rna-transcription/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "rna-transcription",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "comments": [
     "Language implementations vary on the issue of invalid input data.",
     "A language may elect to simplify this task by only presenting valid",
@@ -15,49 +15,49 @@
   ],
   "cases": [
     {
-      "description": "rna complement of cytosine is guanine",
+      "description": "RNA complement of cytosine is guanine",
       "property": "toRna",
       "dna": "C",
       "expected": "G"
     },
     {
-      "description": "rna complement of guanine is cytosine",
+      "description": "RNA complement of guanine is cytosine",
       "property": "toRna",
       "dna": "G",
       "expected": "C"
     },
     {
-      "description": "rna complement of thymine is adenine",
+      "description": "RNA complement of thymine is adenine",
       "property": "toRna",
       "dna": "T",
       "expected": "A"
     },
     {
-      "description": "rna complement of adenine is uracil",
+      "description": "RNA complement of adenine is uracil",
       "property": "toRna",
       "dna": "A",
       "expected": "U"
     },
     {
-      "description": "rna complement",
+      "description": "RNA complement",
       "property": "toRna",
       "dna": "ACGTGGTCTTAA",
       "expected": "UGCACCAGAAUU"
     },
     {
-      "description": "dna correctly handles invalid input",
+      "description": "DNA correctly handles invalid input",
       "property": "toRna",
       "dna": "U",
       "expected": null
     },
     {
-      "description": "dna correctly handles completely invalid input",
+      "description": "DNA correctly handles completely invalid input",
       "property": "toRna",
       "dna": "XXX",
       "expected": null
     },
     {
-      "description": "dna correctly handles partially invalid input",
+      "description": "DNA correctly handles partially invalid input",
       "property": "toRna",
       "dna": "ACGTXXXCTTAA",
       "expected": null

--- a/exercises/rna-transcription/canonical-data.json
+++ b/exercises/rna-transcription/canonical-data.json
@@ -45,19 +45,19 @@
       "expected": "UGCACCAGAAUU"
     },
     {
-      "description": "DNA correctly handles invalid input",
+      "description": "correctly handles invalid input (RNA instead of DNA)",
       "property": "toRna",
       "dna": "U",
       "expected": null
     },
     {
-      "description": "DNA correctly handles completely invalid input",
+      "description": "correctly handles completely invalid DNA input",
       "property": "toRna",
       "dna": "XXX",
       "expected": null
     },
     {
-      "description": "DNA correctly handles partially invalid input",
+      "description": "correctly handles partially invalid DNA input",
       "property": "toRna",
       "dna": "ACGTXXXCTTAA",
       "expected": null


### PR DESCRIPTION
Because RNA & DNA are biochemically defined abbreviations, they should not be in lower-case, unless there is a technical reason (like in `property` fields or in slugs).